### PR TITLE
Use backend to verify existence of Resonite path

### DIFF
--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -42,7 +42,12 @@ fn main() -> anyhow::Result<()> {
 				.build(),
 		)
 		.plugin(tauri_plugin_store::Builder::default().build())
-		.invoke_handler(tauri::generate_handler![show_window, load_manifest, install_version])
+		.invoke_handler(tauri::generate_handler![
+			show_window,
+			load_manifest,
+			install_version,
+			verify_resonite_path
+		])
 		.manage(Downloader::default())
 		.manage(ResoluteState::default())
 		.setup(|app| {
@@ -176,6 +181,14 @@ async fn install_version(app: AppHandle, rmod: ResoluteMod, version: ModVersion)
 
 	info!("Successfully installed mod {} v{}", rmod.name, version.semver);
 	Ok(())
+}
+
+#[tauri::command]
+async fn verify_resonite_path(app: AppHandle) -> Result<bool, String> {
+	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
+	tokio::fs::try_exists(resonite_path)
+		.await
+		.map_err(|err| err.to_string())
 }
 
 #[derive(Default)]

--- a/ui/src/components/pages/ModsPage.vue
+++ b/ui/src/components/pages/ModsPage.vue
@@ -48,7 +48,7 @@ import {
 	onMounted,
 	onUnmounted,
 } from 'vue';
-import { exists as fsExists } from '@tauri-apps/api/fs';
+import { invoke } from '@tauri-apps/api';
 import { mdiRefresh } from '@mdi/js';
 
 import useSettings from '../../settings';
@@ -87,15 +87,15 @@ onBeforeMount(checkIfResonitePathExists);
 watch(settings.current, checkIfResonitePathExists);
 
 /**
- * Checks whether the Resonite path is configured and exists
+ * Checks whether the Resonite path is configured and exists via the backend
  */
 async function checkIfResonitePathExists() {
 	if (!settings.current.resonitePath) {
 		resonitePathExists.value = null;
 	} else {
-		resonitePathExists.value = await fsExists(
-			settings.current.resonitePath,
-		).catch(() => false);
+		resonitePathExists.value = await invoke('verify_resonite_path').catch(
+			() => false,
+		);
 	}
 }
 


### PR DESCRIPTION
When the frontend checks for existence of the path, it is restricted to the filesystem scopes that have been permitted for it. The frontend doesn't have any extra scopes on a fresh launch. It was only granted the scope to the directory upon the user choosing it in the selection dialog triggered by the settings. After a relaunch, however, those scopes are no longer active.

This moves the responsibility of checking the existence of the Resonite path on the mods page to the backend, thus avoiding any scope issues entirely.