### PR TITLE
Wait for settings to load before rendering app

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,5 +16,9 @@ export default [
 	...compat.extends('plugin:prettier-vue/recommended'),
 
 	{ ignores: ['ui/dist', 'target'] },
-	{ plugins: { vue } },
+
+	{
+		plugins: { vue },
+		languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+	},
 ];

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -21,13 +21,13 @@ import UpdateDialog from './components/UpdateDialog.vue';
 import SetupGuideDialog from './components/SetupGuideDialog.vue';
 
 const settings = useSettings();
-settings.init();
+await settings.init();
 
 const themeMediaMatcher = window.matchMedia('(prefers-color-scheme: dark)');
 const systemTheme = ref(themeMediaMatcher.matches ? 'dark' : 'light');
 const theme = computed(() => settings.current.theme ?? systemTheme.value);
 
-onMounted(async () => {
+onMounted(() => {
 	info('App mounted - showing main window');
 	setTimeout(() => invoke('show_window'), 50);
 	themeMediaMatcher.addEventListener('change', onMatchMediaChange);

--- a/ui/src/AppWrapper.vue
+++ b/ui/src/AppWrapper.vue
@@ -1,0 +1,9 @@
+<template>
+	<Suspense>
+		<App />
+	</Suspense>
+</template>
+
+<script setup>
+import App from './App.vue';
+</script>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -6,7 +6,7 @@ import { aliases, mdi } from 'vuetify/iconsets/mdi-svg';
 import { attachConsole } from 'tauri-plugin-log-api';
 
 import { disableContextMenu, disableTextSelection } from './util';
-import App from './App.vue';
+import AppWrapper from './AppWrapper.vue';
 import DashboardPage from './components/pages/DashboardPage.vue';
 import ModsPage from './components/pages/ModsPage.vue';
 import ModAuthorToolsPage from './components/pages/ModAuthorToolsPage.vue';
@@ -26,7 +26,7 @@ attachConsole().then(() => {
 		],
 	});
 
-	createApp(App)
+	createApp(AppWrapper)
 		.use(router)
 		.use(createPinia())
 		.use(


### PR DESCRIPTION
This should prevent a brief flash of the wrong theme and various incorrect elements at slower startups or when reloading