### PR TITLE
Share reqwest client for all file downloads, add timeout, use rustls, and allow compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1648,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +2922,7 @@ version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
+ "async-compression",
  "base64 0.21.5",
  "bytes",
  "encoding_rs",
@@ -2903,6 +2932,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2912,12 +2942,15 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -2925,6 +2958,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg 0.50.0",
 ]
 
@@ -2951,6 +2985,7 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "log",
+ "reqwest",
  "resolute",
  "serde",
  "serde_json",
@@ -2986,6 +3021,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.37.0",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom 0.2.11",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3041,6 +3090,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.5",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3167,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -3378,6 +3468,12 @@ dependencies = [
  "libc",
  "system-deps 5.0.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -3972,6 +4068,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4177,6 +4283,12 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4439,6 +4551,12 @@ dependencies = [
  "soup2-sys",
  "system-deps 6.2.0",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "webview2-com"

--- a/crates/resolute/Cargo.toml
+++ b/crates/resolute/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2021"
 tokio = { version = "1.34", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+url = { version = "2.5", features = ["serde"] }
 thiserror = "1.0"
 log = "0.4"
-url = { version = "2.5", features = ["serde"] }
-reqwest = { version = "0.11", features = ["default", "stream"] }
+reqwest = { version = "0.11", features = ["stream"] }
 futures-util = "0.3"
 path-clean = "1.0"
 sha2 = "0.10"

--- a/crates/resolute/src/manifest.rs
+++ b/crates/resolute/src/manifest.rs
@@ -18,95 +18,109 @@ use crate::{Error, Result};
 pub const MANIFEST_URL: &str =
 	"https://raw.githubusercontent.com/resonite-modding-group/resonite-mod-manifest/main/manifest.json";
 
-/// Downloads the manifest JSON and caches it if necessary
-pub async fn download(config: &ManifestConfig) -> Result<String> {
-	// Download the manifest
-	info!("Downloading manifest from {}", config.remote_url);
-	let response = reqwest::get(config.remote_url.clone()).await?;
-	let status = response.status();
-	if !status.is_success() {
-		return Err(Error::Http(status));
-	}
-	let json = response.text().await?;
-
-	// Cache the JSON to disk if necessary
-	if let Some(cache) = &config.cache_file_path {
-		info!("Caching manifest to {}", cache.display());
-		let mut file = fs::OpenOptions::new()
-			.write(true)
-			.create(true)
-			.truncate(true)
-			.open(cache)
-			.await?;
-		io::copy(&mut json.as_bytes(), &mut file).await?;
-	}
-
-	Ok(json)
+/// Client for performing manifest-related actions
+#[derive(Default)]
+pub struct Client {
+	config: Config,
+	http_client: reqwest::Client,
 }
 
-/// Obtains the manifest JSON either from the cache (if it exists and isn't stale) or by downloading it
-pub async fn retrieve(config: &ManifestConfig) -> Result<String> {
-	// If we don't have a cache file path, go ahead and do a download
-	let Some(cache) = &config.cache_file_path else {
-		return download(config).await;
-	};
+impl Client {
+	/// Creates a new Client
+	pub fn new(config: Config, http_client: reqwest::Client) -> Self {
+		Self { config, http_client }
+	}
 
-	match fs::OpenOptions::new().read(true).open(cache).await {
-		Ok(mut file) => {
-			// Ensure the cache isn't stale - if it is, we try downloading the manifest instead.
-			// If that fails for any reason, we'll use the cache anyway.
-			if let Some(stale_after) = config.cache_stale_after {
-				let modified = file.metadata().await?.modified()?;
-				let stale_time = modified
-					.checked_add(stale_after)
-					.expect("unable to calculate cache staleness threshold");
-				if SystemTime::now().gt(&stale_time) {
-					info!(
-						"Manifest cache is stale (older than {} seconds) - redownloading",
-						stale_after.as_secs()
-					);
-					match download(config).await {
-						Ok(json) => return Ok(json),
-						Err(err) => warn!("Failed to download manifest to replace stale cache: {}", err),
+	/// Creates a new ClientBuilder with defaults set
+	pub fn builder() -> ClientBuilder {
+		ClientBuilder::default()
+	}
+
+	/// Downloads the manifest JSON and caches it if necessary
+	pub async fn download(&self) -> Result<String> {
+		// Download the manifest
+		info!("Downloading manifest from {}", self.config.remote_url);
+		let response = self.http_client.get(self.config.remote_url.clone()).send().await?;
+		let status = response.status();
+		if !status.is_success() {
+			return Err(Error::Http(status));
+		}
+		let json = response.text().await?;
+
+		// Cache the JSON to disk if necessary
+		if let Some(cache) = &self.config.cache_file_path {
+			info!("Caching manifest to {}", cache.display());
+			let mut file = fs::OpenOptions::new()
+				.write(true)
+				.create(true)
+				.truncate(true)
+				.open(cache)
+				.await?;
+			io::copy(&mut json.as_bytes(), &mut file).await?;
+		}
+
+		Ok(json)
+	}
+
+	/// Obtains the manifest JSON either from the cache (if it exists and isn't stale) or by downloading it
+	pub async fn retrieve(&self) -> Result<String> {
+		// If we don't have a cache file path, go ahead and do a download
+		let Some(cache) = &self.config.cache_file_path else {
+			return self.download().await;
+		};
+
+		match fs::OpenOptions::new().read(true).open(cache).await {
+			Ok(mut file) => {
+				// Ensure the cache isn't stale - if it is, we try downloading the manifest instead.
+				// If that fails for any reason, we'll use the cache anyway.
+				if let Some(stale_after) = self.config.cache_stale_after {
+					let modified = file.metadata().await?.modified()?;
+					let stale_time = modified
+						.checked_add(stale_after)
+						.expect("unable to calculate cache staleness threshold");
+					if SystemTime::now().gt(&stale_time) {
+						info!(
+							"Manifest cache is stale (older than {} seconds) - redownloading",
+							stale_after.as_secs()
+						);
+						match self.download().await {
+							Ok(json) => return Ok(json),
+							Err(err) => warn!("Failed to download manifest to replace stale cache: {}", err),
+						}
 					}
 				}
+
+				// Read the JSON from the cache
+				info!("Reading from manifest cache at {}", cache.display());
+				let mut json = String::new();
+				file.read_to_string(&mut json).await?;
+				Ok(json)
 			}
 
-			// Read the JSON from the cache
-			info!("Reading from manifest cache at {}", cache.display());
-			let mut json = String::new();
-			file.read_to_string(&mut json).await?;
-			Ok(json)
+			Err(err) => {
+				warn!("Error opening manifest cache: {}", err);
+				self.download().await
+			}
 		}
+	}
 
-		Err(err) => {
-			warn!("Error opening manifest cache: {}", err);
-			download(config).await
-		}
+	/// Deserializes manifest JSON
+	pub fn parse(&self, json: &str) -> Result<ManifestData> {
+		Ok(serde_json::from_str(json)?)
 	}
 }
 
-/// Deserializes manifest JSON
-pub fn parse(json: &str) -> Result<ManifestData> {
-	Ok(serde_json::from_str(json)?)
+/// Builder for a Client with a custom configuration
+#[derive(Default)]
+pub struct ClientBuilder {
+	config: Config,
+	http_client: reqwest::Client,
 }
 
-/// Configuration for the manifest
-#[derive(Clone, Debug)]
-pub struct ManifestConfig {
-	pub remote_url: Url,
-	pub cache_file_path: Option<PathBuf>,
-	pub cache_stale_after: Option<Duration>,
-}
-
-impl ManifestConfig {
-	/// Creates a new manifest configuration with defaults set
+impl ClientBuilder {
+	/// Creates a new builder with defaults set
 	pub fn new() -> Self {
-		Self {
-			remote_url: Url::parse(MANIFEST_URL).expect("cannot parse default manifest url"),
-			cache_file_path: None,
-			cache_stale_after: Some(Duration::from_secs(60 * 60 * 6)),
-		}
+		Self::default()
 	}
 
 	/// Sets the URL of the remote manifest file for downloads
@@ -115,36 +129,66 @@ impl ManifestConfig {
 		U: TryInto<Url>,
 		<U as TryInto<Url>>::Error: std::fmt::Debug,
 	{
-		self.remote_url = url.try_into().expect("unable to parse given url");
+		self.config.remote_url = url.try_into().expect("unable to parse given url");
 		self
 	}
 
 	/// Sets the cache file path to use
 	pub fn cache(mut self, path: PathBuf) -> Self {
-		self.cache_file_path = Some(path);
+		self.config.cache_file_path = Some(path);
 		self
 	}
 
 	/// Disables caching (and clears any cache file path that was previously set)
 	pub fn no_cache(mut self) -> Self {
-		self.cache_file_path = None;
+		self.config.cache_file_path = None;
 		self
 	}
 
 	/// Marks the cache as stale after a provided duration
 	pub fn stale_after(mut self, duration: Duration) -> Self {
-		self.cache_stale_after = Some(duration);
+		self.config.cache_stale_after = Some(duration);
 		self
 	}
 
 	/// Ensures the cache is never considered stale
 	pub fn never_stale(mut self) -> Self {
-		self.cache_stale_after = None;
+		self.config.cache_stale_after = None;
 		self
+	}
+
+	/// Sets the HTTP client to use
+	pub fn http_client(mut self, http_client: reqwest::Client) -> Self {
+		self.http_client = http_client;
+		self
+	}
+
+	/// Creates a Client using this builder's configuration and HTTP client
+	pub fn build(self) -> Client {
+		Client::new(self.config, self.http_client)
 	}
 }
 
-impl Default for ManifestConfig {
+/// Configuration for manifest Client behavior
+#[derive(Clone, Debug)]
+pub struct Config {
+	pub remote_url: Url,
+	pub cache_file_path: Option<PathBuf>,
+	pub cache_stale_after: Option<Duration>,
+}
+
+impl Config {
+	/// Creates a new manifest configuration with defaults set
+	pub fn new() -> Self {
+		Self {
+			remote_url: Url::parse(MANIFEST_URL).expect("cannot parse default manifest url"),
+			cache_file_path: None,
+			cache_stale_after: Some(Duration::from_secs(60 * 60 * 6)),
+		}
+	}
+}
+
+impl Default for Config {
 	fn default() -> Self {
 		Self::new()
 	}

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -14,22 +14,29 @@ tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
 resolute = { path = "../resolute" }
-tauri = { version = "1.5", features = [
-	"process-relaunch",
-	"dialog-message",
-	"updater",
-	"dialog-ask",
-	"path-all",
-	"fs-exists",
-	"dialog-open",
-	"shell-open",
-] }
 tokio = { version = "1.34", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
 log = "0.4"
 sha2 = "0.10"
+reqwest = { version = "0.11", features = [
+	"rustls-tls",
+	"stream",
+	"gzip",
+	"brotli",
+	"deflate",
+], default-features = false }
+tauri = { version = "1.5", features = [
+	"updater",
+	"dialog-ask",
+	"dialog-message",
+	"dialog-open",
+	"fs-exists",
+	"path-all",
+	"process-relaunch",
+	"shell-open",
+] }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", features = [
 	"colored",
 ] }


### PR DESCRIPTION
This does the following:
- Shares a single reqwest HTTP client across all file downloads (manifest, mod artifacts, etc.)
- Adds a 10s timeout to connections
- Forces the use of rustls instead of native-tls (primarily so TLS 1.3 functions properly on Windows)
- Allows response compression for requests