### PR TITLE
Only log debug level and higher for release builds

### DIFF
--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -40,12 +40,14 @@ fn main() -> anyhow::Result<()> {
 				tauri_plugin_log::Builder::default()
 					.targets(vec![LogTarget::Stdout, LogTarget::Webview])
 					.with_colors(ColoredLevelConfig::default())
+					.level_for("rustls", log::LevelFilter::Debug)
 					.build()
 			},
 			#[cfg(not(debug_assertions))]
 			{
 				tauri_plugin_log::Builder::default()
 					.targets(vec![LogTarget::Stdout, LogTarget::LogDir])
+					.level(log::LevelFilter::Debug)
 					.build()
 			},
 		)


### PR DESCRIPTION
This filters the logging to only log debug level messages and higher in release builds. Also, for development builds, rusttls trace logs are excluded.