### PR TITLE
Add a button to manually run Resonite path discovery

### DIFF
--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -63,6 +63,7 @@ fn main() -> anyhow::Result<()> {
 			show_window,
 			load_manifest,
 			install_version,
+			discover_resonite_path,
 			verify_resonite_path,
 			hash_file
 		])
@@ -159,7 +160,7 @@ async fn autodiscover_resonite_path(app: AppHandle) -> Result<(), anyhow::Error>
 		// Run discovery
 		let resonite_dir = tauri::async_runtime::spawn_blocking(|| discover_resonite(None))
 			.await
-			.context("Unable to spawn blocking task for discovery")??;
+			.context("Unable to spawn blocking task for Resonite path autodiscovery")??;
 
 		// If discovery found a path, save it to the setting
 		match resonite_dir {
@@ -242,6 +243,28 @@ async fn install_version(app: AppHandle, rmod: ResoluteMod, version: ModVersion)
 
 	info!("Successfully installed mod {} v{}", rmod.name, version.semver);
 	Ok(())
+}
+
+#[tauri::command]
+async fn discover_resonite_path() -> Result<Option<String>, String> {
+	let path = tauri::async_runtime::spawn_blocking(|| discover_resonite(None))
+		.await
+		.map_err(|err| {
+			error!("Unable to spawn blocking task for Resonite path discovery: {}", err);
+			format!("Unable to spawn blocking task for Resonite path discovery: {}", err)
+		})?
+		.map_err(|err| {
+			error!("Unable to discover Resonite path: {}", err);
+			format!("Unable to discover Resonite path: {}", err)
+		})?;
+
+	match path {
+		Some(path) => path.to_str().map(|path| Some(path.to_owned())).ok_or_else(|| {
+			error!("Unable to convert discovered Resonite path ({:?}) to a String", path);
+			"Unable to convert discovered Resonite path to a String".to_owned()
+		}),
+		None => Ok(None),
+	}
 }
 
 #[tauri::command]


### PR DESCRIPTION
This allows users to manually run the Resonite path discovery and get immediate feedback on its result, both during the setup guide and when revisiting it later in the settings.