### PR TITLE
Add Installed Mods page

### DIFF
--- a/crates/resolute/src/error.rs
+++ b/crates/resolute/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
 	#[error("io error: {0}")]
 	Io(#[from] std::io::Error),
 
+	#[error("task error: {0}")]
+	Task(#[from] tokio::task::JoinError),
+
 	#[error("unable to process path: {0}")]
 	Path(String),
 

--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -66,6 +66,7 @@ fn main() -> anyhow::Result<()> {
 		.invoke_handler(tauri::generate_handler![
 			show_window,
 			load_all_mods,
+			load_installed_mods,
 			install_mod_version,
 			discover_resonite_path,
 			verify_resonite_path,
@@ -244,7 +245,7 @@ fn show_window(window: Window) -> Result<(), String> {
 	Ok(())
 }
 
-/// Loads the manifest data and parses it into a mod map
+/// Loads all mods from the manager
 #[tauri::command]
 async fn load_all_mods(
 	app: AppHandle,
@@ -277,6 +278,18 @@ async fn load_all_mods(
 		.get_all_mods(manifest_config, bypass_cache)
 		.await
 		.map_err(|err| format!("Unable to get all mods from manager: {}", err))?;
+	Ok(mods)
+}
+
+/// Loads installed mods from the manager
+#[tauri::command]
+async fn load_installed_mods(manager: tauri::State<'_, Mutex<ModManager<'_>>>) -> Result<ResoluteModMap, String> {
+	let mods = manager
+		.lock()
+		.await
+		.get_installed_mods()
+		.await
+		.map_err(|err| format!("Unable to get installed mods from manager: {}", err))?;
 	Ok(mods)
 }
 

--- a/ui/src/components/AppSidebar.vue
+++ b/ui/src/components/AppSidebar.vue
@@ -1,54 +1,37 @@
 <template>
 	<v-navigation-drawer :rail="!isExpanded" permanent width="180">
 		<v-list nav>
-			<v-tooltip text="Dashboard" :open-delay="500" :disabled="isExpanded">
-				<template #activator="{ props }">
-					<v-list-item
-						title="Dashboard"
-						:prepend-icon="mdiViewDashboard"
-						to="/"
-						v-bind="props"
-					/>
-				</template>
-			</v-tooltip>
-
-			<v-tooltip text="All Mods" :open-delay="500" :disabled="isExpanded">
-				<template #activator="{ props }">
-					<v-list-item
-						title="All Mods"
-						:prepend-icon="mdiPackageVariantClosedPlus"
-						to="/mods"
-						v-bind="props"
-					/>
-				</template>
-			</v-tooltip>
-
-			<v-tooltip
+			<SidebarItem
+				label="Dashboard"
+				path="/"
+				:icon="mdiViewDashboard"
+				:expanded="isExpanded"
+			/>
+			<SidebarItem
+				label="Mod Index"
+				path="/mods"
+				:icon="mdiPackageDown"
+				:expanded="isExpanded"
+			/>
+			<SidebarItem
+				label="Installed Mods"
+				path="/mods/installed"
+				:icon="mdiPackageCheck"
+				:expanded="isExpanded"
+			/>
+			<SidebarItem
 				v-if="settings.current.modAuthorTools"
-				text="Author Tools"
-				:open-delay="500"
-				:disabled="isExpanded"
-			>
-				<template #activator="{ props }">
-					<v-list-item
-						title="Author Tools"
-						:prepend-icon="mdiToolbox"
-						to="/author-tools"
-						v-bind="props"
-					/>
-				</template>
-			</v-tooltip>
-
-			<v-tooltip text="Settings" :open-delay="500" :disabled="isExpanded">
-				<template #activator="{ props }">
-					<v-list-item
-						title="Settings"
-						:prepend-icon="mdiCog"
-						to="/settings"
-						v-bind="props"
-					/>
-				</template>
-			</v-tooltip>
+				label="Author Tools"
+				path="/author-tools"
+				:icon="mdiToolbox"
+				:expanded="isExpanded"
+			/>
+			<SidebarItem
+				label="Settings"
+				path="/settings"
+				:icon="mdiCog"
+				:expanded="isExpanded"
+			/>
 		</v-list>
 
 		<template #append>
@@ -76,7 +59,8 @@
 import { ref } from 'vue';
 import {
 	mdiViewDashboard,
-	mdiPackageVariantClosedPlus,
+	mdiPackageDown,
+	mdiPackageCheck,
 	mdiToolbox,
 	mdiCog,
 	mdiMenuClose,
@@ -85,6 +69,7 @@ import {
 
 import useSettings from '../composables/settings';
 import sidebarBus from '../sidebar-bus';
+import SidebarItem from './SidebarItem.vue';
 
 const emit = defineEmits(['toggle']);
 const settings = useSettings();

--- a/ui/src/components/ModTable.vue
+++ b/ui/src/components/ModTable.vue
@@ -98,6 +98,7 @@ const props = defineProps({
 	mods: { type: Object, default: null },
 	disabled: { type: Boolean, default: false },
 	loading: { type: Boolean, default: false },
+	allowGrouping: { type: Boolean, default: true },
 });
 const settings = useSettings();
 
@@ -114,7 +115,7 @@ const headers = computed(() => {
 	];
 
 	// If the mods should be grouped, ditch the category header
-	if (settings.current.groupMods) {
+	if (props.allowGrouping && settings.current.groupModIndex) {
 		const categoryIdx = headers.findIndex((head) => head.key === 'category');
 		headers.splice(categoryIdx, 1);
 	}
@@ -130,9 +131,12 @@ const items = computed(() => (props.mods ? Object.values(props.mods) : []));
 /**
  * groupBy parameter for the data table - automatically adjusted based on whether mods should be grouped
  */
-const groupBy = computed(() =>
-	settings.current.groupMods ? [{ key: 'category', order: 'asc' }] : undefined,
-);
+const groupBy = computed(() => {
+	if (!props.allowGrouping) return undefined;
+	return settings.current.groupModIndex
+		? [{ key: 'category', order: 'asc' }]
+		: undefined;
+});
 
 /**
  * Text to filter the table with

--- a/ui/src/components/SidebarItem.vue
+++ b/ui/src/components/SidebarItem.vue
@@ -1,0 +1,21 @@
+<template>
+	<v-tooltip :text="label" :open-delay="500" :disabled="expanded">
+		<template #activator="{ props }">
+			<v-list-item
+				:title="label"
+				:prepend-icon="icon"
+				:to="path"
+				v-bind="props"
+			/>
+		</template>
+	</v-tooltip>
+</template>
+
+<script setup>
+defineProps({
+	label: { type: String, required: true },
+	path: { type: String, required: true },
+	icon: { type: String, required: true },
+	expanded: { type: Boolean, required: false },
+});
+</script>

--- a/ui/src/components/pages/AllModsPage.vue
+++ b/ui/src/components/pages/AllModsPage.vue
@@ -1,0 +1,53 @@
+<template>
+	<ModsPage
+		title="Mod Index"
+		:mods="modStore.mods"
+		:load-mods="modStore.load"
+		:disabled="!resonitePathExists"
+	>
+		<template #alerts>
+			<v-alert
+				v-if="!resonitePathExists"
+				type="warning"
+				:rounded="false"
+				density="comfortable"
+				class="rounded-0"
+			>
+				{{
+					resonitePathExists === null
+						? 'Please configure the Resonite path in the settings.'
+						: "The configured Resonite path doesn't seem to exist. Please check the settings."
+				}}
+			</v-alert>
+		</template>
+	</ModsPage>
+</template>
+
+<script setup>
+import { ref, watch, onBeforeMount } from 'vue';
+import { invoke } from '@tauri-apps/api';
+
+import useSettings from '../../composables/settings';
+import useModStore from '../../stores/mods';
+import ModsPage from './ModsPage.vue';
+
+const settings = useSettings();
+const modStore = useModStore();
+const resonitePathExists = ref(true);
+
+onBeforeMount(checkIfResonitePathExists);
+watch(settings.current, checkIfResonitePathExists);
+
+/**
+ * Checks whether the Resonite path is configured and exists via the backend
+ */
+async function checkIfResonitePathExists() {
+	if (!settings.current.resonitePath) {
+		resonitePathExists.value = null;
+	} else {
+		resonitePathExists.value = await invoke('verify_resonite_path').catch(
+			() => false,
+		);
+	}
+}
+</script>

--- a/ui/src/components/pages/InstalledModsPage.vue
+++ b/ui/src/components/pages/InstalledModsPage.vue
@@ -1,0 +1,36 @@
+<template>
+	<ModsPage
+		title="Installed Mods"
+		:mods="mods"
+		:load-mods="loadMods"
+		:allow-grouping="false"
+	/>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+import useModStore from '../../stores/mods';
+import ModsPage from './ModsPage.vue';
+
+const modStore = useModStore();
+const mods = computed(() => {
+	if (!modStore.mods) return modStore.mods;
+
+	const mods = {};
+	for (const mod of Object.values(modStore.mods)) {
+		if (!mod.installedVersion) continue;
+		mods[mod.id] = mod;
+	}
+
+	return mods;
+});
+
+/**
+ * Loads installed mods first, then loads all mods from the manifest to fill in any updated data
+ */
+async function loadMods() {
+	await modStore.loadInstalled();
+	await modStore.load(false, false).catch(() => {});
+}
+</script>

--- a/ui/src/components/pages/SettingsPage.vue
+++ b/ui/src/components/pages/SettingsPage.vue
@@ -14,7 +14,10 @@
 				<v-container>
 					<DropdownSetting setting="theme" :items="themes" label="Theme" />
 					<ResonitePathSetting />
-					<CheckboxSetting setting="groupMods" label="Group mods by category" />
+					<CheckboxSetting
+						setting="groupModIndex"
+						label="Group Mod Index by category"
+					/>
 					<v-btn @click="settings.current.setupGuideDone = false">
 						Setup guide
 					</v-btn>

--- a/ui/src/composables/settings.js
+++ b/ui/src/composables/settings.js
@@ -9,7 +9,7 @@ const currentSettings = reactive({
 	resonitePath: null,
 	manifestUrl: null,
 	theme: null,
-	groupMods: true,
+	groupModIndex: true,
 	modsPerPageGrouped: -1,
 	modsPerPageUngrouped: 25,
 	modAuthorTools: false,

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -8,7 +8,8 @@ import { attachConsole } from 'tauri-plugin-log-api';
 import { disableContextMenu, disableTextSelection } from './util';
 import AppWrapper from './AppWrapper.vue';
 import DashboardPage from './components/pages/DashboardPage.vue';
-import ModsPage from './components/pages/ModsPage.vue';
+import AllModsPage from './components/pages/AllModsPage.vue';
+import InstalledModsPage from './components/pages/InstalledModsPage.vue';
 import ModAuthorToolsPage from './components/pages/ModAuthorToolsPage.vue';
 import SettingsPage from './components/pages/SettingsPage.vue';
 
@@ -20,7 +21,8 @@ attachConsole().then(() => {
 		history: createWebHashHistory(),
 		routes: [
 			{ path: '/', component: DashboardPage },
-			{ path: '/mods', component: ModsPage },
+			{ path: '/mods', component: AllModsPage },
+			{ path: '/mods/installed', component: InstalledModsPage },
 			{ path: '/author-tools', component: ModAuthorToolsPage },
 			{ path: '/settings', component: SettingsPage },
 		],


### PR DESCRIPTION
Adds a new "Installed Mods" page that lists all installed mods loaded from the database, regardless of connectivity and access to the manifest. With access to a manifest, the latest data is also loaded so as to show up-to-date version information.

Also adjusts the existing "All Mods" page to be called "Mod Index".

![image](https://github.com/Gawdl3y/Resolute/assets/279900/7554e31f-d1ab-45b5-83a2-d7558cdfd37c)

Closes #79