### PR TITLE
Bypass manifest cache with installed mods refresh button

### DIFF
--- a/ui/src/components/pages/InstalledModsPage.vue
+++ b/ui/src/components/pages/InstalledModsPage.vue
@@ -28,9 +28,10 @@ const mods = computed(() => {
 
 /**
  * Loads installed mods first, then loads all mods from the manifest to fill in any updated data
+ * @param {boolean} [bypassCache=false] Whether to bypass the manifest cache
  */
-async function loadMods() {
+async function loadMods(bypassCache = false) {
 	await modStore.loadInstalled();
-	await modStore.load(false, false).catch(() => {});
+	await modStore.load(bypassCache, false).catch(() => {});
 }
 </script>

--- a/ui/src/components/pages/ModsPage.vue
+++ b/ui/src/components/pages/ModsPage.vue
@@ -7,7 +7,7 @@
 						:icon="mdiRefresh"
 						:loading="loading"
 						v-bind="tooltipProps"
-						@click="loadMods(true)"
+						@click="loadModsFromFn(true)"
 					/>
 				</template>
 			</v-tooltip>


### PR DESCRIPTION
Fixes the refresh button on the installed mods page not bypassing the manifest cache.