### PR TITLE
Space out version number and status icon

### DIFF
--- a/ui/src/components/ModTable.vue
+++ b/ui/src/components/ModTable.vue
@@ -18,7 +18,7 @@
 				</td>
 				<td>{{ mod.description }}</td>
 				<td v-if="!groupBy">{{ mod.category }}</td>
-				<td><ModVersionStatus :mod="mod" /></td>
+				<td style="width: 7em"><ModVersionStatus :mod="mod" /></td>
 				<td>
 					<ModInstaller v-slot="{ install, installing, busy }" :mod="mod.id">
 						<v-tooltip text="Install" :open-delay="500">

--- a/ui/src/components/ModVersionStatus.vue
+++ b/ui/src/components/ModVersionStatus.vue
@@ -3,7 +3,7 @@
 		<template #activator="{ props: activator }">
 			<div
 				v-bind="activator"
-				class="d-flex gc-2 align-center"
+				class="d-flex gc-2 align-center justify-space-between"
 				:class="mod.versionTextClass"
 			>
 				{{ mod.installedVersion?.semver ?? mod.latestVersion.semver }}


### PR DESCRIPTION
This adds space between the version number and status indicator icon on installed mods.

# Before
![image](https://github.com/Gawdl3y/Resolute/assets/279900/8b261d40-c6ad-46c5-ad81-6b68ef5e01c7)

# After
![image](https://github.com/Gawdl3y/Resolute/assets/279900/2c54395e-19f7-4399-9363-2ca1950c254b)
