### PR TITLE
Open repo in new window from link on dashboard

### DIFF
--- a/ui/src/components/pages/DashboardPage.vue
+++ b/ui/src/components/pages/DashboardPage.vue
@@ -31,7 +31,11 @@
 					nerd.
 				</p>
 				<p>
-					<a href="https://github.com/Gawdl3y/Resolute" title="Source code">
+					<a
+						href="https://github.com/Gawdl3y/Resolute"
+						target="_blank"
+						title="Source code"
+					>
 						<v-icon :icon="mdiSourceBranch" />
 					</a>
 				</p>


### PR DESCRIPTION
Fixes the dashboard's repo/source code link opening within the application window rather than a browser window.