### PR TITLE
Fix external links not opening at all

### DIFF
--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -38,6 +38,7 @@ tauri = { version = "1.5", features = [
 	"fs-exists",
 	"path-all",
 	"process-relaunch",
+	"shell-open",
 ] }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", features = [
 	"colored",

--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -28,6 +28,10 @@
 			"process": {
 				"all": false,
 				"relaunch": true
+			},
+			"shell": {
+				"all": false,
+				"open": true
 			}
 		},
 		"bundle": {


### PR DESCRIPTION
This fixes external links not opening when clicking on them. This was caused by the removal of the shell open permission in the Tauri feature allowlist, so this PR just re-adds that.