### PR TITLE
Add update all button to installed mods page

### DIFF
--- a/ui/src/components/pages/ModsPage.vue
+++ b/ui/src/components/pages/ModsPage.vue
@@ -1,6 +1,8 @@
 <template>
 	<AppHeader :title="title">
 		<template #actions>
+			<slot name="actions" />
+
 			<v-tooltip text="Refresh mods" :open-delay="500">
 				<template #activator="{ props: tooltipProps }">
 					<v-btn

--- a/ui/src/stores/mods.js
+++ b/ui/src/stores/mods.js
@@ -111,6 +111,7 @@ export const useModStore = defineStore('mods', () => {
 				title: 'Error installing mod',
 				type: 'error',
 			});
+			throw err;
 		} finally {
 			// Clear the operation for the mod
 			operations[modID] = null;


### PR DESCRIPTION
Adds an "Update all" button to the installed mods page that is only enabled when there are any mods with an available update. Clicking it triggers an install for all outdated mods and then presents a summary of succeeded and failed updates to the user.