### PR TITLE
Add installed mod discovery

### DIFF
--- a/crates/resolute/src/discover.rs
+++ b/crates/resolute/src/discover.rs
@@ -1,9 +1,18 @@
-use std::path::PathBuf;
+use std::{
+	collections::HashMap,
+	fs, io,
+	path::{Path, PathBuf},
+};
 
-use log::debug;
+use log::{debug, error, trace};
+use sha2::{Digest, Sha256};
 use steamlocate::SteamDir;
 
-use crate::Result;
+use crate::{
+	manager::ArtifactPaths,
+	mods::{ResoluteMod, ResoluteModMap},
+	Result,
+};
 
 pub const RESONITE_APP: u32 = 2_519_830;
 
@@ -29,4 +38,96 @@ pub fn discover_resonite(steam: Option<SteamDir>) -> Result<Option<PathBuf>> {
 		}
 		None => Ok(None),
 	}
+}
+
+/// Searches for any installed mods in a Resonite directory
+pub fn discover_mods(base_path: impl AsRef<Path>, mods: ResoluteModMap) -> Result<ResoluteModMap> {
+	let mut discovered = ResoluteModMap::new();
+	let mut checksums: HashMap<PathBuf, Option<String>> = HashMap::new();
+	let base_path = base_path.as_ref().to_path_buf();
+
+	'mods: for (id, rmod) in mods {
+		'versions: for (semver, version) in &rmod.versions {
+			trace!("Scanning for artifacts from mod {} v{}", rmod, semver);
+
+			'_artifacts: for artifact in &version.artifacts {
+				trace!("Checking for artifact {} from mod {} v{}", artifact, rmod, semver);
+
+				// Build the path that the artifact would use
+				let path = match ArtifactPaths::try_new(artifact, &base_path) {
+					Ok(paths) => base_path.join(paths.final_dest),
+					Err(_err) => continue 'versions,
+				};
+
+				// Check the checksum cache for the file
+				match checksums.get(&path) {
+					// Checksum has already been calculated - just check it against the artifact's hash and
+					// move on if it doesn't match
+					Some(Some(checksum)) => {
+						if *checksum != artifact.sha256.to_lowercase() {
+							trace!(
+								"Artifact {} checksum mismatch (expected = {}, actual(cached) = {})",
+								artifact,
+								artifact.sha256,
+								checksum
+							);
+							continue 'versions;
+						}
+					}
+
+					// File has been encountered but doesn't exist - move on to the next version
+					Some(None) => {
+						trace!("Artifact {} file doesn't exist (cached)", artifact);
+						continue 'versions;
+					}
+
+					// File hasn't yet been encountered
+					None => {}
+				};
+
+				// Open the file - if we're unable to, add that fact to the checksum cache
+				let mut file = match fs::File::open(&path) {
+					Ok(file) => file,
+					Err(err) => {
+						trace!("Artifact file {} can't be opened: {}", artifact, err);
+						checksums.insert(path, None);
+						continue 'versions;
+					}
+				};
+
+				// Calculate the file's checksum
+				let mut hasher = Sha256::new();
+				let hash = match io::copy(&mut file, &mut hasher) {
+					Ok(_bytes) => format!("{:x}", hasher.finalize()),
+					Err(err) => {
+						error!("Error hashing artifact file {}: {}", artifact, err);
+						continue 'versions;
+					}
+				};
+				checksums.insert(path, Some(hash.clone()));
+
+				// If the hash doesn't match, move on to the next version
+				if hash != artifact.sha256.to_lowercase() {
+					trace!(
+						"Artifact {} checksum mismatch (expected = {}, actual = {})",
+						artifact,
+						artifact.sha256,
+						hash
+					);
+					continue 'versions;
+				}
+			}
+
+			// A matched version has been found
+			debug!("Discovered installed mod {} v{}", rmod, semver);
+			let rmod = ResoluteMod {
+				installed_version: Some(semver.clone()),
+				..rmod.clone()
+			};
+			discovered.insert(id.clone(), rmod);
+			continue 'mods;
+		}
+	}
+
+	Ok(discovered)
 }

--- a/crates/resolute/src/manager/paths.rs
+++ b/crates/resolute/src/manager/paths.rs
@@ -8,7 +8,7 @@ use path_clean::PathClean;
 use crate::{mods::ModArtifact, Error, Result};
 
 /// Contains full paths that an artifact may live in at various stages of installation
-#[derive(Clone, Debug, PartialEq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ArtifactPaths {
 	/// Full path for an artifact file that has been installed
 	pub final_dest: PathBuf,
@@ -64,5 +64,3 @@ impl ArtifactPaths {
 		})
 	}
 }
-
-impl Eq for ArtifactPaths {}

--- a/ui/src/components/SetupGuideDialog.vue
+++ b/ui/src/components/SetupGuideDialog.vue
@@ -206,7 +206,7 @@ const prereqsInstalled = ref(0);
 
 onMounted(() => {
 	info('Setup guide showing');
-	if (!modStore.mods) modStore.load();
+	if (!modStore.mods && !modStore.loading) modStore.load();
 });
 
 /**
@@ -225,6 +225,16 @@ function advanceStep() {
 			await settings.set('allowClosingSetupGuide', true, false);
 			await settings.persist();
 		}, 500);
+
+		// Kick off mod autodiscovery
+		if (!settings.current.modsAutodiscovered && !modStore.discovering) {
+			modStore
+				.discover()
+				.then(() => {
+					settings.set('modsAutodiscovered', true);
+				})
+				.catch(() => {});
+		}
 	}
 }
 

--- a/ui/src/components/mods/ModInstaller.vue
+++ b/ui/src/components/mods/ModInstaller.vue
@@ -13,12 +13,22 @@ import { ref, computed } from 'vue';
 
 import useModStore from '../../stores/mods';
 
-const props = defineProps({ mod: { type: Object, required: true } });
+const props = defineProps({
+	mod: {
+		required: true,
+		validator(val) {
+			if (!val) return false;
+			return typeof val === 'object' || typeof val === 'string';
+		},
+	},
+});
 const emit = defineEmits(['install', 'error']);
 
 const modStore = useModStore();
-const busy = computed(() => modStore.isBusy(props.mod.id));
-const installing = computed(() => modStore.isInstalling(props.mod.id));
+const busy = computed(() => modStore.isBusy(props.mod?.id ?? props.mod));
+const installing = computed(() =>
+	modStore.isInstalling(props.mod?.id ?? props.mod),
+);
 const installed = ref(false);
 const error = ref(null);
 
@@ -27,7 +37,7 @@ const error = ref(null);
  */
 async function install() {
 	try {
-		await modStore.install(props.mod.id);
+		await modStore.install(props.mod?.id ?? props.mod);
 		installed.value = true;
 		emit('install');
 	} catch (err) {

--- a/ui/src/components/pages/AllModsPage.vue
+++ b/ui/src/components/pages/AllModsPage.vue
@@ -1,53 +1,19 @@
 <template>
-	<ModsPage
-		title="Mod Index"
-		:mods="modStore.mods"
-		:load-mods="modStore.load"
-		:disabled="!resonitePathExists"
-	>
-		<template #alerts>
-			<v-alert
-				v-if="!resonitePathExists"
-				type="warning"
-				:rounded="false"
-				density="comfortable"
-				class="rounded-0"
-			>
-				{{
-					resonitePathExists === null
-						? 'Please configure the Resonite path in the settings.'
-						: "The configured Resonite path doesn't seem to exist. Please check the settings."
-				}}
-			</v-alert>
-		</template>
-	</ModsPage>
+	<ModsPage title="Mod Index" :mods="modStore.mods" :load-mods="loadMods" />
 </template>
 
 <script setup>
-import { ref, watch, onBeforeMount } from 'vue';
-import { invoke } from '@tauri-apps/api';
-
-import useSettings from '../../composables/settings';
 import useModStore from '../../stores/mods';
 import ModsPage from './ModsPage.vue';
 
-const settings = useSettings();
 const modStore = useModStore();
-const resonitePathExists = ref(true);
-
-onBeforeMount(checkIfResonitePathExists);
-watch(settings.current, checkIfResonitePathExists);
 
 /**
- * Checks whether the Resonite path is configured and exists via the backend
+ * Loads all mods from the backend
+ * @param {boolean} [bypassCache=false] Whether to bypass the manifest cache
  */
-async function checkIfResonitePathExists() {
-	if (!settings.current.resonitePath) {
-		resonitePathExists.value = null;
-	} else {
-		resonitePathExists.value = await invoke('verify_resonite_path').catch(
-			() => false,
-		);
-	}
+async function loadMods(bypassCache = false) {
+	if (modStore.loading) return;
+	await modStore.load(bypassCache);
 }
 </script>

--- a/ui/src/composables/settings.js
+++ b/ui/src/composables/settings.js
@@ -15,6 +15,7 @@ const currentSettings = reactive({
 	modAuthorTools: false,
 	setupGuideDone: false,
 	allowClosingSetupGuide: false,
+	modsAutodiscovered: false,
 });
 
 export function useSettings() {


### PR DESCRIPTION
- Adds mod discovery functionality
  * Automatically runs once after the setup guide is done
  * Can be triggered manually with the button on the installed mods page
- Allows the ModInstaller to accept mod IDs again
- Prevents requesting loads of mods when they're already being loaded
- Moves the invalid Resonite path alert to ModsPage
