### PR TITLE
Replace empty mod table text with more descriptive messages

### DIFF
--- a/ui/src/components/mods/ModTable.vue
+++ b/ui/src/components/mods/ModTable.vue
@@ -7,6 +7,7 @@
 		:loading="loading"
 		:search="filter"
 		:group-by="groupBy"
+		:no-data-text="noDataText"
 		fixed-header
 		hover
 		@update:items-per-page="onItemsPerPageUpdate"
@@ -152,6 +153,7 @@ const props = defineProps({
 	disabled: { type: Boolean, default: false },
 	loading: { type: Boolean, default: false },
 	allowGrouping: { type: Boolean, default: true },
+	noDataText: { type: String, default: undefined },
 });
 const emit = defineEmits(['showModDetails']);
 const settings = useSettings();

--- a/ui/src/components/pages/AllModsPage.vue
+++ b/ui/src/components/pages/AllModsPage.vue
@@ -1,5 +1,10 @@
 <template>
-	<ModsPage title="Mod Index" :mods="modStore.mods" :load-mods="loadMods" />
+	<ModsPage
+		title="Mod Index"
+		no-data-text="No mod data is available."
+		:mods="modStore.mods"
+		:load-mods="loadMods"
+	/>
 </template>
 
 <script setup>

--- a/ui/src/components/pages/InstalledModsPage.vue
+++ b/ui/src/components/pages/InstalledModsPage.vue
@@ -1,6 +1,7 @@
 <template>
 	<ModsPage
 		title="Installed Mods"
+		no-data-text="No mods have been installed yet."
 		:mods="mods"
 		:load-mods="loadMods"
 		:allow-grouping="false"

--- a/ui/src/components/pages/ModsPage.vue
+++ b/ui/src/components/pages/ModsPage.vue
@@ -41,6 +41,7 @@
 			:loading="loading"
 			:style="`height: ${tableHeight}`"
 			:allow-grouping="allowGrouping"
+			:no-data-text="noDataText"
 			@show-mod-details="showModDetails"
 		/>
 	</v-main>
@@ -77,6 +78,7 @@ const props = defineProps({
 	loadMods: { type: Function, required: true },
 	disabled: { type: Boolean, default: false },
 	allowGrouping: { type: Boolean, default: true },
+	noDataText: { type: String, default: undefined },
 });
 const settings = useSettings();
 const modStore = useModStore();


### PR DESCRIPTION
This overrides the default empty table placeholder text for the mod tables on both the installed mods page and all mods page.