### PR TITLE
Disable tao runner warnings in release builds

### DIFF
--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -50,6 +50,10 @@ fn main() -> anyhow::Result<()> {
 				tauri_plugin_log::Builder::default()
 					.targets(vec![LogTarget::Stdout, LogTarget::LogDir])
 					.level(log::LevelFilter::Debug)
+					.level_for(
+						"tao::platform_impl::platform::event_loop::runner",
+						log::LevelFilter::Error,
+					)
 					.build()
 			},
 		)


### PR DESCRIPTION
This silences those noisy warnings on Windows coming from Tao's event loop runner whenever an application window loses/regains focus.