### PR TITLE
Preserve older logs after rotation

### DIFF
--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -47,8 +47,12 @@ fn main() -> anyhow::Result<()> {
 			},
 			#[cfg(not(debug_assertions))]
 			{
+				use tauri_plugin_log::RotationStrategy;
+
 				tauri_plugin_log::Builder::default()
 					.targets(vec![LogTarget::Stdout, LogTarget::LogDir])
+					.rotation_strategy(RotationStrategy::KeepAll)
+					.max_file_size(1024 * 256)
 					.level(log::LevelFilter::Debug)
 					.level_for(
 						"tao::platform_impl::platform::event_loop::runner",


### PR DESCRIPTION
This configures the log file rotation to allow the logs to get to 256KB before rotating and also preserves the logs that get rotated out.