### PR TITLE
Wrap mod names at CamelCase word boundaries

### DIFF
--- a/ui/src/components/mods/ModTable.vue
+++ b/ui/src/components/mods/ModTable.vue
@@ -19,9 +19,12 @@
 				@click="emit('showModDetails', mod)"
 			>
 				<td v-if="groupBy"></td>
-				<td style="max-width: 14em; overflow-wrap: break-word">
-					{{ mod.name }}
-				</td>
+				<!-- eslint-disable vue/no-v-html -->
+				<td
+					style="min-width: 12em; max-width: 16em; overflow-wrap: break-word"
+					v-html="wrappableCamelCase(mod.name)"
+				></td>
+				<!-- eslint-enable vue/no-v-html -->
 				<td>{{ mod.description }}</td>
 				<td v-if="!groupBy">{{ mod.category }}</td>
 				<td style="width: 7em"><ModVersionStatus :mod="mod" /></td>
@@ -142,6 +145,7 @@
 import { ref, computed } from 'vue';
 import { mdiDownload, mdiDelete, mdiUpdate, mdiRefresh } from '@mdi/js';
 
+import { wrappableCamelCase } from '../../util';
 import useSettings from '../../composables/settings';
 import ModVersionStatus from './ModVersionStatus.vue';
 import ModInstaller from './ModInstaller.vue';

--- a/ui/src/util.js
+++ b/ui/src/util.js
@@ -49,6 +49,16 @@ export function renderMarkdown(markdown) {
 }
 
 /**
+ * Inserts HTML <wbr> tags in between CamelCase word sections (and sanitizes the input)
+ * @param {*} text
+ * @returns
+ */
+export function wrappableCamelCase(text) {
+	const pure = purify.sanitize(text, { ALLOWED_TAGS: ['#text'] });
+	return pure.replace(/([a-z])([A-Z])/g, '$1<wbr />$2');
+}
+
+/**
  * Disables the context menu for a node
  * @param {Node} [node=document]
  */


### PR DESCRIPTION
This greatly improves the text wrapping behaviour for mod names in the mod tables by inserting word breaks in between CamelCase word sections.