### PR TITLE
Don't block any text selection/deselection for inputs

### DIFF
--- a/ui/src/util.js
+++ b/ui/src/util.js
@@ -84,6 +84,7 @@ export function disableTextSelection(node = document) {
 		(evt) => {
 			if (isInput || !(evt.target instanceof HTMLInputElement)) {
 				evt.preventDefault();
+				window.getSelection().removeAllRanges();
 				return false;
 			}
 		},

--- a/ui/src/util.js
+++ b/ui/src/util.js
@@ -78,11 +78,14 @@ export function disableContextMenu(node = document) {
  * @param {Node} [node=document]
  */
 export function disableTextSelection(node = document) {
+	const isInput = node instanceof HTMLInputElement;
 	node.addEventListener(
 		'selectstart',
 		(evt) => {
-			evt.preventDefault();
-			return false;
+			if (isInput || !(evt.target instanceof HTMLInputElement)) {
+				evt.preventDefault();
+				return false;
+			}
 		},
 		{ capture: true },
 	);


### PR DESCRIPTION
- Fixes text selection with Ctrl + A in text inputs
- Allows deselecting text by clicking outside of inputs