### PR TITLE
Allow settings tabs to be navigated to with the tab key

### DIFF
--- a/ui/src/components/pages/SettingsPage.vue
+++ b/ui/src/components/pages/SettingsPage.vue
@@ -2,7 +2,7 @@
 	<AppHeader title="Settings">
 		<template #extension>
 			<v-tabs v-model="tab">
-				<v-tab value="general">General</v-tab>
+				<v-tab value="general" tabindex="0">General</v-tab>
 				<v-tab value="advanced">Advanced</v-tab>
 			</v-tabs>
 		</template>


### PR DESCRIPTION
This adds a tabindex to the first settings tab to allow the tab strip to be navigated to with just a keyboard.