### PR TITLE
Add expand/collapse all button to mod index

### DIFF
--- a/ui/src/components/pages/AllModsPage.vue
+++ b/ui/src/components/pages/AllModsPage.vue
@@ -4,13 +4,16 @@
 		no-data-text="No mod data is available."
 		:mods="modStore.mods"
 		:load-mods="loadMods"
+		:grouped="settings.current.groupModIndex"
 	/>
 </template>
 
 <script setup>
+import useSettings from '../../composables/settings';
 import useModStore from '../../stores/mods';
 import ModsPage from './ModsPage.vue';
 
+const settings = useSettings();
 const modStore = useModStore();
 
 /**

--- a/ui/src/components/pages/InstalledModsPage.vue
+++ b/ui/src/components/pages/InstalledModsPage.vue
@@ -4,7 +4,7 @@
 		no-data-text="No mods have been installed yet."
 		:mods="mods"
 		:load-mods="loadMods"
-		:allow-grouping="false"
+		:grouped="false"
 	>
 		<template #actions="{ resonitePathExists }">
 			<v-tooltip text="Discover installed" :open-delay="500">

--- a/ui/src/components/pages/ModsPage.vue
+++ b/ui/src/components/pages/ModsPage.vue
@@ -3,6 +3,20 @@
 		<template #actions>
 			<slot name="actions" :resonite-path-exists="resonitePathExists" />
 
+			<v-tooltip
+				v-if="grouped"
+				:text="`${expanded ? 'Collapse' : 'Expand'} all`"
+				:open-delay="500"
+			>
+				<template #activator="{ props: tooltipProps }">
+					<v-btn
+						:icon="expanded ? mdiArrowCollapseVertical : mdiArrowExpandVertical"
+						v-bind="tooltipProps"
+						@click="toggleAllGroups"
+					/>
+				</template>
+			</v-tooltip>
+
 			<v-tooltip text="Refresh mods" :open-delay="500">
 				<template #activator="{ props: tooltipProps }">
 					<v-btn
@@ -36,11 +50,12 @@
 		</div>
 
 		<ModTable
+			ref="modTable"
 			:mods="mods"
 			:disabled="disabled || !resonitePathExists"
 			:loading="loading"
 			:style="`height: ${tableHeight}`"
-			:allow-grouping="allowGrouping"
+			:grouped="grouped"
 			:no-data-text="noDataText"
 			@show-mod-details="showModDetails"
 		/>
@@ -63,7 +78,11 @@ import {
 	onUnmounted,
 } from 'vue';
 import { invoke } from '@tauri-apps/api';
-import { mdiRefresh } from '@mdi/js';
+import {
+	mdiArrowCollapseVertical,
+	mdiArrowExpandVertical,
+	mdiRefresh,
+} from '@mdi/js';
 
 import useSettings from '../../composables/settings';
 import useModStore from '../../stores/mods';
@@ -77,16 +96,18 @@ const props = defineProps({
 	mods: { type: Object, default: null },
 	loadMods: { type: Function, required: true },
 	disabled: { type: Boolean, default: false },
-	allowGrouping: { type: Boolean, default: true },
+	grouped: { type: Boolean, default: true },
 	noDataText: { type: String, default: undefined },
 });
+
 const settings = useSettings();
 const modStore = useModStore();
-const alerts = ref(null);
+
 const loading = ref(false);
 const resonitePathExists = ref(true);
 const modDetails = ref(null);
 
+const alerts = ref(null);
 const alertHeight = ref(0);
 const tableHeight = computed(() => {
 	if (!alerts.value) return '100%';
@@ -121,6 +142,7 @@ onUnmounted(() => {
 	sidebarBus.off('toggle', onSidebarToggle);
 });
 
+// Validate the Resonite path on load and change
 onBeforeMount(checkIfResonitePathExists);
 watch(settings.current, checkIfResonitePathExists);
 
@@ -194,5 +216,17 @@ function adjustTableHeight() {
  */
 function onSidebarToggle() {
 	adjustTableHeight();
+}
+
+const modTable = ref(null);
+const expanded = ref(false);
+
+/**
+ * Expands or collapses all groups in the mod table
+ */
+function toggleAllGroups() {
+	expanded.value = !expanded.value;
+	if (expanded.value) modTable.value.expandAllGroups();
+	else modTable.value.collapseAllGroups();
 }
 </script>


### PR DESCRIPTION
Adds a button to expand/collapse all mod groups to the mod index when grouping is enabled.

Closes #103