### PR TITLE
Don't force NSIS installer from updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,6 @@ jobs:
       releaseBody: ${{ needs.changelog.outputs.changelog }}
       releaseDraft: true
       includeUpdaterJson: true
-      updaterJsonPreferNsis: true
     secrets:
       updaterKey: ${{ secrets.TAURI_UPDATER_KEY }}
       updaterKeyPassword: ${{ secrets.TAURI_UPDATER_KEY_PASSWORD }}


### PR DESCRIPTION
Setting the updater to prefer NSIS right now results in some odd behaviour when the user has chosen to use an MSI installer and then updates the app, especially if the install location was customized.