### PR TITLE
Display inferrable artifact filename and destination

### DIFF
--- a/ui/src/components/mods/ModArtifactsTable.vue
+++ b/ui/src/components/mods/ModArtifactsTable.vue
@@ -4,19 +4,29 @@
 			<th scope="col">Filename</th>
 			<th scope="col">Destination</th>
 			<th scope="col">URL</th>
-			<th scope="col">Checksum</th>
+			<th scope="col">SHA-256 Checksum</th>
 		</thead>
 		<tbody>
 			<tr v-for="artifact of artifacts" :key="artifact.sha256">
 				<td>
 					<span v-if="artifact.filename">{{ artifact.filename }}</span>
-					<span v-else class="text-disabled">&lt;unspecified&gt;</span>
+					<v-tooltip v-else text="Inferred from the URL">
+						<template #activator="{ props: tooltipProps }">
+							<span v-bind="tooltipProps">
+								{{ artifact.inferredFilename }}*
+							</span>
+						</template>
+					</v-tooltip>
 				</td>
 				<td>
 					<span v-if="artifact.installLocation">
 						{{ artifact.installLocation }}
 					</span>
-					<span v-else class="text-disabled">&lt;unspecified&gt;</span>
+					<v-tooltip v-else text="Default destination">
+						<template #activator="{ props: tooltipProps }">
+							<span v-bind="tooltipProps">/rml_mods*</span>
+						</template>
+					</v-tooltip>
 				</td>
 				<td>
 					<a :href="artifact.url" target="_blank">{{ artifact.url }}</a>

--- a/ui/src/structs/mod.js
+++ b/ui/src/structs/mod.js
@@ -225,4 +225,24 @@ export class ModArtifact {
 		 */
 		this.installLocation = data.installLocation;
 	}
+
+	/**
+	 * The inferred filename of the artifact (obtained from the end of the URL)
+	 * @returns {string}
+	 */
+	get inferredFilename() {
+		const url = new URL(this.url);
+		const lastSlashIdx = url.pathname.lastIndexOf('/');
+		return url.pathname.substring(lastSlashIdx + 1);
+	}
+
+	/**
+	 * Gets the inferred install location of the artifact
+	 * (always "/rml_mods" unless the given category is "Plugins", in which case it's "/Libraries")
+	 * @returns {string}
+	 */
+	inferredInstallLocation(category) {
+		if (category === 'Plugins') return '/Libraries';
+		return '/rml_mods';
+	}
 }


### PR DESCRIPTION
- When an artifact's filename is unspecified, the artifact details will now show the inferred filename from the URL
- When an artifact's destination is unspecified, the artifact details will now show the default "rml_mods" directory