### PR TITLE
Discover and display unrecognized mods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3305,6 +3305,7 @@ dependencies = [
  "native_model",
  "path-clean",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,6 +3303,7 @@ dependencies = [
  "log",
  "native_db",
  "native_model",
+ "once_cell",
  "path-clean",
  "reqwest",
  "semver",

--- a/crates/resolute/Cargo.toml
+++ b/crates/resolute/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 tokio = { version = "1.34", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+semver = "1.0"
 url = { version = "2.5", features = ["serde"] }
 thiserror = "1.0"
 log = "0.4"

--- a/crates/resolute/Cargo.toml
+++ b/crates/resolute/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1.34", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 semver = "1.0"
+once_cell = "1.19"
 url = { version = "2.5", features = ["serde"] }
 thiserror = "1.0"
 log = "0.4"

--- a/crates/resolute/src/db.rs
+++ b/crates/resolute/src/db.rs
@@ -58,20 +58,27 @@ impl<'a> ResoluteDatabase<'a> {
 		Ok(())
 	}
 
-	/// Removes a mod from the database by its ID
-	pub fn remove_mod(&self, id: impl AsRef<str>) -> Result<()> {
-		// Find the item in the database
-		let id = id.as_ref().to_string();
-		let read = self.db.r_transaction()?;
-		let rmod: ResoluteMod = read.get().primary(id.clone())?.ok_or_else(|| Error::ItemNotFound(id))?;
+	/// Removes a mod from the database
+	pub fn remove_mod(&self, rmod: ResoluteMod) -> Result<()> {
 		let mod_name = rmod.to_string();
 
-		// Remove it
+		// Remove the mod
 		let rw = self.db.rw_transaction()?;
 		rw.remove(rmod)?;
 		rw.commit()?;
 
 		info!("Removed mod {} from the database", mod_name);
 		Ok(())
+	}
+
+	/// Removes a mod from the database by its ID
+	pub fn remove_mod_by_id(&self, id: impl AsRef<str>) -> Result<()> {
+		// Find the item in the database
+		let id = id.as_ref().to_string();
+		let read = self.db.r_transaction()?;
+		let rmod: ResoluteMod = read.get().primary(id.clone())?.ok_or_else(|| Error::ItemNotFound(id))?;
+
+		// Remove it
+		self.remove_mod(rmod)
 	}
 }

--- a/crates/resolute/src/discover.rs
+++ b/crates/resolute/src/discover.rs
@@ -1,5 +1,6 @@
 use std::{
 	collections::HashMap,
+	ffi::OsString,
 	fs, io,
 	path::{Path, PathBuf},
 };
@@ -10,7 +11,7 @@ use steamlocate::SteamDir;
 
 use crate::{
 	manager::ArtifactPaths,
-	mods::{ResoluteMod, ResoluteModMap},
+	mods::{ModVersion, ResoluteMod, ResoluteModMap},
 	Result,
 };
 
@@ -40,8 +41,15 @@ pub fn discover_resonite(steam: Option<SteamDir>) -> Result<Option<PathBuf>> {
 	}
 }
 
-/// Searches for any installed mods in a Resonite directory
+/// Searches for any installed mods in a Resonite directory by checksum then filename, including unrecognized mods
 pub fn discover_mods(base_path: impl AsRef<Path>, mods: ResoluteModMap) -> Result<ResoluteModMap> {
+	let mut discovered = discover_mods_by_checksum(&base_path, &mods)?;
+	discovered.extend(discover_mods_by_filename(&base_path, &mods, Some(&discovered))?);
+	Ok(discovered)
+}
+
+/// Searches for any installed mods in a Resonite directory using artifact checksums
+pub fn discover_mods_by_checksum(base_path: impl AsRef<Path>, mods: &ResoluteModMap) -> Result<ResoluteModMap> {
 	let mut discovered = ResoluteModMap::new();
 	let mut checksums: HashMap<PathBuf, Option<String>> = HashMap::new();
 	let base_path = base_path.as_ref().to_path_buf();
@@ -126,6 +134,153 @@ pub fn discover_mods(base_path: impl AsRef<Path>, mods: ResoluteModMap) -> Resul
 			};
 			discovered.insert(id.clone(), rmod);
 			continue 'mods;
+		}
+	}
+
+	Ok(discovered)
+}
+
+/// Searches for any installed mods in a Resonite directory using artifact filenames
+pub fn discover_mods_by_filename(
+	base_path: impl AsRef<Path>,
+	mods: &ResoluteModMap,
+	already_discovered: Option<&ResoluteModMap>,
+) -> Result<ResoluteModMap> {
+	let mut discovered = ResoluteModMap::new();
+	let base_path = base_path.as_ref();
+	let search_dirs = vec!["rml_mods", "rml_libs"];
+
+	for dirname in search_dirs {
+		let path = base_path.join(dirname);
+		trace!("Scanning for artifact files in {}", path.display());
+
+		// Read the files in the path
+		let files = match fs::read_dir(&path) {
+			Ok(files) => files,
+			Err(err) => {
+				debug!("Artifact search path ({}) cannot be read: {}", path.display(), err);
+				continue;
+			}
+		};
+
+		for artifact_file in files {
+			// Get the file details
+			let artifact_file = match artifact_file {
+				Ok(file) => file,
+				Err(err) => {
+					debug!("Artifact file cannot be listed: {}", err);
+					continue;
+				}
+			};
+
+			let artifact_path = artifact_file.path();
+			debug!("Looking for mods for artifact file {}", artifact_path.display());
+
+			// If the file is present in the already-discovered mods, skip it
+			if let Some(already_discovered) = already_discovered {
+				let exists = already_discovered.values().any(|rmod| {
+					let installed_version = rmod
+						.installed_version
+						.as_ref()
+						.expect("unable to get installed version of discovered mod");
+
+					rmod.versions
+						.get(installed_version)
+						.expect("unable to get installed version from discovered mod versions map")
+						.artifacts
+						.iter()
+						.any(|artifact| {
+							artifact
+								.filename
+								.as_ref()
+								.map(|filename| OsString::from(&filename))
+								.or_else(|| artifact.infer_filename())
+								.expect("unable to get filename of artifact")
+								== artifact_file.file_name()
+						})
+				});
+
+				if exists {
+					debug!(
+						"Artifact file {} is part of an already-discovered mod",
+						artifact_path.display()
+					);
+					continue;
+				}
+			}
+
+			// Get the first known mod that has this filename in its artifacts
+			let existing_rmod = mods.values().find(|rmod| {
+				rmod.versions.values().any(|version| {
+					version.artifacts.iter().any(|artifact| {
+						artifact
+							.filename
+							.as_ref()
+							.map(|filename| OsString::from(&filename))
+							.or_else(|| artifact.infer_filename())
+							.expect("unable to get filename of artifact")
+							== artifact_file.file_name()
+					})
+				})
+			});
+
+			// Calculate the checksum of the file
+			let sha256 = {
+				// Open the file
+				let mut file = match fs::File::open(&artifact_path) {
+					Ok(file) => file,
+					Err(err) => {
+						error!("Artifact file {} can't be opened: {}", artifact_path.display(), err);
+						continue;
+					}
+				};
+
+				// Calculate the checksum
+				let mut hasher = Sha256::new();
+				match io::copy(&mut file, &mut hasher) {
+					Ok(_bytes) => format!("{:x}", hasher.finalize()),
+					Err(err) => {
+						error!("Error hashing artifact file {}: {}", artifact_path.display(), err);
+						continue;
+					}
+				}
+			};
+
+			// Get a str representation of the filename
+			let filename = artifact_file.file_name();
+			let filename = match filename.to_str() {
+				Some(filename) => filename,
+				None => {
+					error!(
+						"Error converting artifact file name ({:?}) to string",
+						artifact_file.file_name()
+					);
+					continue;
+				}
+			};
+
+			// Create an unrecognized mod
+			let rmod = match existing_rmod {
+				Some(rmod) => {
+					let version = ModVersion::new_unrecognized(filename, dirname, sha256);
+					let semver = version.semver.clone();
+
+					let mut rmod = rmod.clone();
+					rmod.versions.insert(semver.clone(), version);
+					rmod.installed_version = Some(semver.clone());
+
+					debug!("Created unrecognized version {} for existing mod {}", semver, rmod);
+					rmod
+				}
+
+				None => {
+					let rmod = ResoluteMod::new_unrecognized(filename, dirname, sha256);
+					debug!("Created unrecognized mod {}", rmod);
+					rmod
+				}
+			};
+
+			discovered.insert(rmod.id.clone(), rmod);
 		}
 	}
 

--- a/crates/resolute/src/discover.rs
+++ b/crates/resolute/src/discover.rs
@@ -189,15 +189,7 @@ pub fn discover_mods_by_filename(
 						.expect("unable to get installed version from discovered mod versions map")
 						.artifacts
 						.iter()
-						.any(|artifact| {
-							artifact
-								.filename
-								.as_ref()
-								.map(|filename| OsString::from(&filename))
-								.or_else(|| artifact.infer_filename())
-								.expect("unable to get filename of artifact")
-								== artifact_file.file_name()
-						})
+						.any(|artifact| artifact.usable_filename() == artifact_file.file_name())
 				});
 
 				if exists {

--- a/crates/resolute/src/error.rs
+++ b/crates/resolute/src/error.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Display, path::PathBuf};
 
 use reqwest::StatusCode;
+use semver::Version;
 
 use crate::mods::ResoluteMod;
 
@@ -25,6 +26,9 @@ pub enum Error {
 	#[error("unable to parse url: {0}")]
 	Url(String),
 
+	#[error("unable to parse semver: {0}")]
+	Semver(#[from] semver::Error),
+
 	#[error("json error: {0}")]
 	Json(#[from] serde_json::Error),
 
@@ -36,7 +40,7 @@ pub enum Error {
 	},
 
 	#[error("unknown version \"{1}\" for mod \"{0}\"")]
-	UnknownVersion(String, String),
+	UnknownVersion(String, Version),
 
 	#[error("mod \"{0}\" isn't installed")]
 	ModNotInstalled(Box<ResoluteMod>),

--- a/crates/resolute/src/manager/mod.rs
+++ b/crates/resolute/src/manager/mod.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use log::debug;
 use semver::Version;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "db")]
 use crate::db::ResoluteDatabase;
@@ -60,20 +61,23 @@ impl_ModManager_with_without_db! {
 
 		/// Gets all mods that have a version installed
 		#[cfg(feature = "db")]
-		pub async fn get_installed_mods(&self) -> Result<ResoluteModMap> {
-			let mods = tokio::task::block_in_place(move || -> Result<ResoluteModMap> {
-				Ok(self
+		pub async fn get_installed_mods(&self) -> Result<LoadedMods> {
+			let mods = tokio::task::block_in_place(move || -> Result<LoadedMods> {
+				let mods = self
 					.db
 					.get_installed_mods()?
 					.into_iter()
 					.map(|rmod| (rmod.id.clone(), rmod))
-					.collect())
+					.collect();
+
+				Ok(LoadedMods { mods, removed: None })
 			})?;
 			Ok(mods)
 		}
 
-		/// Gets all mods from a manifest, and if the "db" feature is active, marks any installed ones
-		pub async fn get_all_mods(&self, manifest_config: manifest::Config, bypass_cache: bool) -> Result<ResoluteModMap> {
+		/// Gets all mods from a manifest, and if the "db" feature is active, marks any installed ones.
+		/// Returns a tuple of the mods and any removed mods (if applicable).
+		pub async fn get_all_mods(&self, manifest_config: manifest::Config, bypass_cache: bool) -> Result<LoadedMods> {
 			let manifest = manifest::Client::new(manifest_config, self.http_client.clone());
 
 			// Retrieve the manifest JSON
@@ -93,16 +97,32 @@ impl_ModManager_with_without_db! {
 			.await??;
 
 			#[cfg(feature = "db")]
-			self.mark_installed_mods(&mut mods).await?;
+			let removed = self.mark_installed_mods(&mut mods).await?;
+			#[cfg(not(feature = "db"))]
+			let removed = None;
 
-			Ok(mods)
+			Ok(LoadedMods { mods, removed })
 		}
 
 		/// Fills in the installed_version field for all mods in a map that are installed and
-		/// adds any necessary missing versions to the mods' versions maps
+		/// adds any necessary missing versions to the mods' versions maps.
+		/// Returns a list of unrecognized mods that should be considered removed, if any.
 		#[cfg(feature = "db")]
-		pub async fn mark_installed_mods(&self, mods: &mut ResoluteModMap) -> Result<()> {
-			let installed_mods = self.get_installed_mods().await?;
+		pub async fn mark_installed_mods(&self, mods: &mut ResoluteModMap) -> Result<Option<ResoluteModMap>> {
+			use std::{collections::HashSet, ffi::OsString};
+
+			use crate::mods::{ModArtifact, ModVersion};
+
+			// Load the installed mods
+			let LoadedMods {
+				mods: installed_mods, ..
+			} = self.get_installed_mods().await?;
+
+			// Get all unrecognized mods
+			let unrecognized_mods: Vec<&ResoluteMod> =
+				installed_mods.values().filter(|rmod| rmod.is_unrecognized()).collect();
+
+			let mut removed_mods = ResoluteModMap::new();
 
 			for (id, rmod) in mods.iter_mut() {
 				if let Some(installed) = installed_mods.get(id) {
@@ -124,9 +144,87 @@ impl_ModManager_with_without_db! {
 						}
 					}
 				}
+
+				if !unrecognized_mods.is_empty() {
+					// Get the latest version of the known mod
+					let latest_version = match rmod.latest_version() {
+						Some(version) => version,
+						None => continue,
+					};
+
+					// Build a set of artifact filenames for the known mod
+					let expected_artifact_names: HashSet<OsString> = latest_version
+						.artifacts
+						.iter()
+						.map(|artifact| artifact.usable_filename())
+						.collect();
+
+					// Find unrecognized mods that contain any of the filenames
+					let unrecognized_matches: Vec<&ResoluteMod> = unrecognized_mods
+						.iter()
+						.filter(|umod| {
+							// Get the latest version of the unrecognized mod
+							let latest_version = match umod.latest_version() {
+								Some(version) => version,
+								None => return false,
+							};
+
+							// Build a set of artifact filenames for the unrecognized mod
+							let artifact_names: HashSet<OsString> = latest_version
+								.artifacts
+								.iter()
+								.map(|artifact| artifact.usable_filename())
+								.collect();
+
+							// Include this unrecognized mod only if all of its artifacts are included in the known mod's
+							return artifact_names.difference(&expected_artifact_names).count() == 0;
+						})
+						.copied()
+						.collect();
+
+					if unrecognized_matches.is_empty() {
+						continue;
+					}
+
+					// Create a new unrecognized version for the mod with the combined artifacts from the unrecognized mods
+					let unrecognized_artifacts: Vec<ModArtifact> = unrecognized_matches
+						.iter()
+						.flat_map(|umod| {
+							let latest_version = umod.latest_version().unwrap();
+							latest_version.artifacts.iter().cloned()
+						})
+						.collect();
+					let unrecognized_version = ModVersion::new_unrecognized_with_artifacts(unrecognized_artifacts);
+
+					// Add the version to the mod's versions map and mark it as the installed version
+					let semver = unrecognized_version.semver.clone();
+					rmod.versions.insert(semver.clone(), unrecognized_version);
+					rmod.installed_version = Some(semver);
+
+					// Replace the unrecognized mods with the known mod in the database
+					tokio::task::block_in_place(|| -> Result<()> {
+						removed_mods.reserve(unrecognized_matches.len());
+
+						for umod in unrecognized_matches {
+							debug!(
+								"Removing unrecognized mod {} from the database during installed mod marking, repacing with {}",
+								umod, rmod
+							);
+							self.db.remove_mod_by_id(&umod.id)?;
+							removed_mods.insert(umod.id.clone(), umod.clone());
+						}
+
+						self.db.store_mod(rmod.clone())?;
+						Ok(())
+					})?;
+				}
 			}
 
-			Ok(())
+			Ok(if removed_mods.is_empty() {
+				None
+			} else {
+				Some(removed_mods)
+			})
 		}
 
 		/// Installs a mod, and if the "db" feature is active, stores it as installed in the database
@@ -199,14 +297,14 @@ impl_ModManager_with_without_db! {
 			// Delete the version artifacts and remove the mod from the database
 			self.deleter.delete_version(installed_version).await?;
 			#[cfg(feature = "db")]
-			tokio::task::block_in_place(|| self.db.remove_mod(&rmod.id))?;
+			tokio::task::block_in_place(|| self.db.remove_mod_by_id(&rmod.id))?;
 
 			Ok(())
 		}
 
 		/// Discovers any installed mods in the base path, and if the "db" feature is active, stores them in the database
 		pub async fn discover_installed_mods(&self, manifest_config: manifest::Config) -> Result<ResoluteModMap> {
-			let all_mods = self.get_all_mods(manifest_config, false).await?;
+			let LoadedMods { mods: all_mods, .. } = self.get_all_mods(manifest_config, false).await?;
 
 			let resonite_path = self.base_dest.clone();
 			let discovered = tokio::task::block_in_place(|| discover::discover_mods(resonite_path, all_mods))?;
@@ -231,4 +329,11 @@ impl_ModManager_with_without_db! {
 			self.deleter.base_dest = path.to_owned();
 		}
 	}
+}
+
+/// A set of loaded mods from a manager
+#[derive(Serialize, Deserialize, Clone)]
+pub struct LoadedMods {
+	pub mods: ResoluteModMap,
+	pub removed: Option<ResoluteModMap>,
 }

--- a/crates/resolute/src/manager/paths.rs
+++ b/crates/resolute/src/manager/paths.rs
@@ -36,9 +36,9 @@ impl ArtifactPaths {
 		// Add the artifact's filename to the path
 		let filename = match &artifact.filename {
 			Some(filename) => OsString::from(filename),
-			None => Path::new(artifact.url.path())
-				.file_name()
-				.ok_or_else(|| Error::Path(format!("unable to extract file name from url: {}", artifact.url)))?
+			None => artifact
+				.infer_filename()
+				.ok_or_else(|| Error::Path(format!("unable to infer filename from url: {}", artifact.url)))?
 				.to_owned(),
 		};
 		dest.push(&filename);

--- a/crates/resolute/src/manifest.rs
+++ b/crates/resolute/src/manifest.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use log::{info, warn};
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use tokio::{
 	fs,
@@ -257,7 +258,7 @@ pub struct ManifestEntry {
 }
 
 /// Represents a "versions" object in the manifest JSON
-pub type ManifestEntryVersions = HashMap<String, ManifestEntryVersion>;
+pub type ManifestEntryVersions = HashMap<Version, ManifestEntryVersion>;
 
 /// Represents a single "versions" entry in the manifest JSON
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -285,5 +286,5 @@ pub type ManifestEntryDependencies = HashMap<String, ManifestEntryDependency>;
 /// Represents a single "dependencies" or "conflicts" entry in the manifest JSON
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ManifestEntryDependency {
-	pub version: String,
+	pub version: VersionReq,
 }

--- a/crates/resolute/src/mods.rs
+++ b/crates/resolute/src/mods.rs
@@ -343,11 +343,19 @@ impl ModArtifact {
 			.push(install_location)
 			.push(filename);
 
+		let install_location = if !install_location.starts_with('/') {
+			let mut install_location = install_location.to_owned();
+			install_location.insert(0, '/');
+			install_location
+		} else {
+			install_location.to_owned()
+		};
+
 		ModArtifact {
 			url,
 			sha256: sha256.to_owned(),
 			filename: Some(filename.to_owned()),
-			install_location: Some(install_location.to_owned()),
+			install_location: Some(install_location),
 		}
 	}
 }

--- a/crates/resolute/src/mods.rs
+++ b/crates/resolute/src/mods.rs
@@ -23,12 +23,17 @@ use crate::manifest::{
 pub const UNRECOGNIZED_GROUP: &str = "dev.gawdl3y.resolute.unrecognized";
 
 /// Semver representing an unknown version
-pub static UNKNOWN_SEMVER: Lazy<Version> = Lazy::new(|| Version {
+pub static UNRECOGNIZED_SEMVER: Lazy<Version> = Lazy::new(|| Version {
 	major: 0,
 	minor: 0,
 	patch: 0,
-	pre: Prerelease::new("unknown").expect("unable to create prerelease struct for unknown semver"),
+	pre: Prerelease::new("unknown").expect("unable to create prerelease struct for unrecognized semver"),
 	build: BuildMetadata::default(),
+});
+
+/// Base URL for an unrecognized artifact
+pub static UNRECOGNIZED_ARTIFACT_BASE_URL: Lazy<Url> = Lazy::new(|| {
+	Url::parse("resolute://unrecognized/artifact").expect("unable to parse unrecognized artifact base url")
 });
 
 /// Builds a mod map from the given raw manifest data
@@ -255,9 +260,9 @@ pub struct ModVersion {
 }
 
 impl ModVersion {
-	/// Checks whether this version is unrecognized (semver equals [UNKNOWN_SEMVER])
+	/// Checks whether this version is unrecognized (semver equals [UNRECOGNIZED_SEMVER])
 	pub fn is_unrecognized(&self) -> bool {
-		self.semver.eq(&UNKNOWN_SEMVER)
+		self.semver.eq(&UNRECOGNIZED_SEMVER)
 	}
 
 	/// Creates a new unrecognized version from details about an encountered artifact file
@@ -266,7 +271,7 @@ impl ModVersion {
 		artifact_install_location: impl AsRef<str>,
 		artifact_sha256: impl AsRef<str>,
 	) -> Self {
-		let semver = UNKNOWN_SEMVER.clone();
+		let semver = UNRECOGNIZED_SEMVER.clone();
 		let artifacts = vec![ModArtifact::new_unrecognized(
 			artifact_filename,
 			artifact_install_location,
@@ -317,6 +322,11 @@ impl ModArtifact {
 		}
 	}
 
+	/// Checks whether this artifact is unrecognized (URL begins with [UNRECOGNIZED_ARTIFACT_BASE_URL])
+	pub fn is_unrecognized(&self) -> bool {
+		self.url.as_str().starts_with(UNRECOGNIZED_ARTIFACT_BASE_URL.as_str())
+	}
+
 	/// Creates a new unrecognized artifact from details about an encountered artifact file
 	pub fn new_unrecognized(
 		filename: impl AsRef<str>,
@@ -327,8 +337,7 @@ impl ModArtifact {
 		let install_location = install_location.as_ref();
 		let sha256 = sha256.as_ref();
 
-		let mut url =
-			Url::parse("resolute://unrecognized/artifact").expect("unable to parse unrecognized artifact base url");
+		let mut url = UNRECOGNIZED_ARTIFACT_BASE_URL.clone();
 		url.path_segments_mut()
 			.expect("unable to get mutable path segments of unrecognized artifact base url")
 			.push(install_location)

--- a/crates/resolute/src/mods.rs
+++ b/crates/resolute/src/mods.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fmt::Display, path::Path};
 
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -63,7 +64,7 @@ fn build_mod_authors(authors: ManifestAuthors) -> Vec<ModAuthor> {
 }
 
 /// Build a versions map from manifest data
-fn build_mod_versions_map(versions: ManifestEntryVersions, category: &str) -> HashMap<String, ModVersion> {
+fn build_mod_versions_map(versions: ManifestEntryVersions, category: &str) -> HashMap<Version, ModVersion> {
 	versions
 		.into_iter()
 		.map(|(semver, version)| ModVersion {
@@ -78,7 +79,7 @@ fn build_mod_versions_map(versions: ManifestEntryVersions, category: &str) -> Ha
 }
 
 /// Build a dependencies map from manifest data for a mod version
-fn build_mod_version_dependencies(dependencies: Option<ManifestEntryDependencies>) -> HashMap<String, String> {
+fn build_mod_version_dependencies(dependencies: Option<ManifestEntryDependencies>) -> HashMap<String, VersionReq> {
 	if let Some(depends) = dependencies {
 		depends
 			.into_iter()
@@ -128,9 +129,9 @@ pub struct ResoluteMod {
 	pub tags: Option<Vec<String>>,
 	pub flags: Option<Vec<String>>,
 	pub platforms: Option<Vec<String>>,
-	pub versions: HashMap<String, ModVersion>,
+	pub versions: HashMap<Version, ModVersion>,
 	#[serde(rename = "installedVersion")]
-	pub installed_version: Option<String>,
+	pub installed_version: Option<Version>,
 }
 
 impl Display for ResoluteMod {
@@ -157,7 +158,7 @@ impl Display for ModAuthor {
 /// Details for a released version of a mod
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModVersion {
-	pub semver: String,
+	pub semver: Version,
 	pub artifacts: Vec<ModArtifact>,
 	pub dependencies: ModDependencyMap,
 	pub conflicts: ModDependencyMap,
@@ -225,4 +226,4 @@ impl From<ManifestEntryArtifact> for ModArtifact {
 }
 
 /// Map of mod IDs to semver ranges
-pub type ModDependencyMap = HashMap<String, String>;
+pub type ModDependencyMap = HashMap<String, VersionReq>;

--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -325,7 +325,7 @@ async fn install_mod_version(
 	// Download the version
 	info!("Installing mod {} v{}", rmod.name, version.semver);
 	manager
-		.install_mod(&rmod, &version.semver, |_, _| {})
+		.install_mod(&rmod, version.semver.to_string(), |_, _| {})
 		.await
 		.map_err(|err| {
 			error!("Failed to download mod {} v{}: {}", rmod.name, version.semver, err);
@@ -364,7 +364,7 @@ async fn replace_mod_version(
 	// Update the mod to the given version
 	info!("Replacing mod {} v{} with v{}", rmod.name, old_version, version.semver);
 	manager
-		.update_mod(&rmod, &version.semver, |_, _| {})
+		.update_mod(&rmod, version.semver.to_string(), |_, _| {})
 		.await
 		.map_err(|err| {
 			error!(

--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -10,7 +10,7 @@ use once_cell::sync::Lazy;
 use resolute::{
 	db::ResoluteDatabase,
 	discover,
-	manager::ModManager,
+	manager::{LoadedMods, ModManager},
 	manifest,
 	mods::{ModVersion, ResoluteMod, ResoluteModMap},
 };
@@ -286,7 +286,7 @@ async fn load_all_mods(
 	app: AppHandle,
 	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
 	bypass_cache: bool,
-) -> Result<ResoluteModMap, String> {
+) -> Result<LoadedMods, String> {
 	let mods = manager
 		.lock()
 		.await
@@ -298,7 +298,7 @@ async fn load_all_mods(
 
 /// Loads installed mods from the manager
 #[tauri::command]
-async fn load_installed_mods(manager: tauri::State<'_, Mutex<ModManager<'_>>>) -> Result<ResoluteModMap, String> {
+async fn load_installed_mods(manager: tauri::State<'_, Mutex<ModManager<'_>>>) -> Result<LoadedMods, String> {
 	let mods = manager
 		.lock()
 		.await

--- a/ui/src/components/SetupGuideDialog.vue
+++ b/ui/src/components/SetupGuideDialog.vue
@@ -227,11 +227,11 @@ function advanceStep() {
 		}, 500);
 
 		// Kick off mod autodiscovery
-		if (!settings.current.modsAutodiscovered && !modStore.discovering) {
+		if (!settings.current.modsAutodiscovered2 && !modStore.discovering) {
 			modStore
 				.discover()
 				.then(() => {
-					settings.set('modsAutodiscovered', true);
+					settings.set('modsAutodiscovered2', true);
 				})
 				.catch(() => {});
 		}

--- a/ui/src/components/mods/ModDetailsDialog.vue
+++ b/ui/src/components/mods/ModDetailsDialog.vue
@@ -58,7 +58,7 @@
 				</ModUpdater>
 
 				<ModInstaller
-					v-else-if="!mod.isUnrecognized"
+					v-else-if="!version.isUnrecognized"
 					v-slot="{ install, installing, busy }"
 					:mod="mod"
 					:version="semver"

--- a/ui/src/components/mods/ModDetailsDialog.vue
+++ b/ui/src/components/mods/ModDetailsDialog.vue
@@ -58,7 +58,7 @@
 				</ModUpdater>
 
 				<ModInstaller
-					v-else
+					v-else-if="!mod.isUnrecognized"
 					v-slot="{ install, installing, busy }"
 					:mod="mod"
 					:version="semver"

--- a/ui/src/components/mods/ModTable.vue
+++ b/ui/src/components/mods/ModTable.vue
@@ -53,7 +53,7 @@
 						</ModUninstaller>
 
 						<ModInstaller
-							v-if="!mod.hasUpdate"
+							v-if="!mod.hasUpdate && !mod.isUnrecognized"
 							v-slot="{ install, installing, busy }"
 							:mod="mod"
 						>
@@ -75,7 +75,11 @@
 							</v-tooltip>
 						</ModInstaller>
 
-						<ModUpdater v-else v-slot="{ update, updating, busy }" :mod="mod">
+						<ModUpdater
+							v-else-if="mod.hasUpdate"
+							v-slot="{ update, updating, busy }"
+							:mod="mod"
+						>
 							<v-tooltip text="Update" :open-delay="500">
 								<template #activator="{ props: activator }">
 									<v-btn

--- a/ui/src/components/mods/ModVersionStatus.vue
+++ b/ui/src/components/mods/ModVersionStatus.vue
@@ -9,9 +9,14 @@
 						class="d-flex gc-2 align-center justify-space-between position-absolute h-100"
 						:class="mod.versionTextClass"
 					>
-						{{ mod.installedVersion?.semver ?? mod.latestVersion.semver }}
+						{{ (mod.installedVersion ?? mod.latestVersion).label }}
 
 						<v-icon v-if="mod.hasUpdate" :icon="mdiAlert" size="small" />
+						<v-icon
+							v-else-if="mod.isUnrecognized"
+							:icon="mdiHelpCircle"
+							size="small"
+						/>
 						<v-icon
 							v-else-if="mod.installedVersion"
 							:icon="mdiCheckCircle"
@@ -22,21 +27,21 @@
 			</div>
 		</template>
 
-		<dl class="d-flex flex-wrap" style="width: 7.25em">
+		<dl class="d-flex flex-wrap" style="width: 9em">
 			<dt class="w-50">Installed:</dt>
 			<dd class="w-50 ms-auto text-end">
-				{{ mod.installedVersion?.semver ?? 'None' }}
+				{{ mod.installedVersion?.label ?? 'None' }}
 			</dd>
 			<dt class="w-50">Latest:</dt>
 			<dd class="w-50 ms-auto text-end">
-				{{ mod.latestVersion.semver }}
+				{{ mod.latestVersion.label }}
 			</dd>
 		</dl>
 	</v-tooltip>
 </template>
 
 <script setup>
-import { mdiCheckCircle, mdiAlert } from '@mdi/js';
+import { mdiCheckCircle, mdiAlert, mdiHelpCircle } from '@mdi/js';
 
 import { ResoluteMod } from '../../structs/mod';
 

--- a/ui/src/components/mods/ModVersionStatus.vue
+++ b/ui/src/components/mods/ModVersionStatus.vue
@@ -27,23 +27,30 @@
 			</div>
 		</template>
 
-		<dl class="d-flex flex-wrap" style="width: 9em">
+		<dl class="d-flex flex-wrap" :style="`width: ${tooltipWidth}`">
 			<dt class="w-50">Installed:</dt>
 			<dd class="w-50 ms-auto text-end">
 				{{ mod.installedVersion?.label ?? 'None' }}
 			</dd>
 			<dt class="w-50">Latest:</dt>
-			<dd class="w-50 ms-auto text-end">
-				{{ mod.latestVersion.label }}
-			</dd>
+			<dd class="w-50 ms-auto text-end">{{ mod.latestVersion.label }}</dd>
 		</dl>
 	</v-tooltip>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { mdiCheckCircle, mdiAlert, mdiHelpCircle } from '@mdi/js';
 
 import { ResoluteMod } from '../../structs/mod';
 
-defineProps({ mod: { type: ResoluteMod, required: true } });
+const props = defineProps({ mod: { type: ResoluteMod, required: true } });
+
+const tooltipWidth = computed(() => {
+	const mod = props.mod;
+	const anyUnrecognized =
+		mod.installedVersion?.isUnrecognized || mod.latestVersion.isUnrecognized;
+	if (anyUnrecognized) return '8.75em';
+	return '7.25em';
+});
 </script>

--- a/ui/src/components/pages/InstalledModsPage.vue
+++ b/ui/src/components/pages/InstalledModsPage.vue
@@ -45,7 +45,7 @@ import ModsPage from './ModsPage.vue';
 
 const modStore = useModStore();
 const mods = computed(() => {
-	if (!modStore.mods) return modStore.mods;
+	if (!modStore.mods || !modStore.hasLoadedInstalled) return null;
 
 	const mods = {};
 	for (const mod of Object.values(modStore.mods)) {
@@ -169,6 +169,7 @@ async function discoverInstalledMods() {
 			type: 'info',
 		});
 	} catch (err) {
+		console.error('Error discovering installed mods', err);
 		message(`Error discovering installed mods:\n${err}`, {
 			title: 'Error discovering mods',
 			type: 'error',

--- a/ui/src/components/pages/ModsPage.vue
+++ b/ui/src/components/pages/ModsPage.vue
@@ -120,14 +120,14 @@ onMounted(() => {
 
 	// Automatically discover mods if it hasn't been done before and the setup guide has already been done
 	const shouldAutodiscover =
-		!settings.current.modsAutodiscovered &&
+		!settings.current.modsAutodiscovered2 &&
 		settings.current.setupGuideDone &&
 		!modStore.discovering;
 	if (shouldAutodiscover) {
 		modStore
 			.discover()
 			.then(() => {
-				settings.set('modsAutodiscovered', true);
+				settings.set('modsAutodiscovered2', true);
 			})
 			.catch(() => {});
 	}

--- a/ui/src/composables/settings.js
+++ b/ui/src/composables/settings.js
@@ -15,7 +15,7 @@ const currentSettings = reactive({
 	modAuthorTools: false,
 	setupGuideDone: false,
 	allowClosingSetupGuide: false,
-	modsAutodiscovered: false,
+	modsAutodiscovered2: false,
 });
 
 export function useSettings() {

--- a/ui/src/stores/mods.js
+++ b/ui/src/stores/mods.js
@@ -14,6 +14,7 @@ export const useModStore = defineStore('mods', () => {
 	const loadingInstalled = ref(false);
 	const discovering = ref(false);
 	const hasLoaded = ref(false);
+	const hasLoadedInstalled = ref(false);
 	const operations = reactive({});
 
 	/**
@@ -68,6 +69,7 @@ export const useModStore = defineStore('mods', () => {
 			const mods = await invoke('load_installed_mods');
 			for (const id of Object.keys(mods)) mods[id] = new ResoluteMod(mods[id]);
 
+			hasLoadedInstalled.value = true;
 			console.debug('Installed mods loaded', mods);
 			info(`${Object.keys(mods).length} installed mods loaded`);
 
@@ -300,6 +302,7 @@ export const useModStore = defineStore('mods', () => {
 		loadingInstalled,
 		discovering,
 		hasLoaded,
+		hasLoadedInstalled,
 		install,
 		uninstall,
 		update,

--- a/ui/src/stores/mods.js
+++ b/ui/src/stores/mods.js
@@ -24,23 +24,38 @@ export const useModStore = defineStore('mods', () => {
 	 * @returns {Object} {@link ResoluteMod}s mapped by their ID
 	 */
 	async function load(bypassCache = false, alert = true) {
+		// Ensure we're not already loading the mods elsewhere
 		if (loading.value) throw new Error('Already loading mods.');
 		loading.value = true;
 
 		try {
+			// Load the mods from the backend
 			await info(`Requesting mod load, bypassCache = ${bypassCache}`);
-			const mods = await invoke('load_all_mods', { bypassCache });
-			for (const id of Object.keys(mods)) mods[id] = new ResoluteMod(mods[id]);
+			const { mods: newMods, removed } = await invoke('load_all_mods', {
+				bypassCache,
+			});
+			for (const id of Object.keys(newMods)) {
+				newMods[id] = new ResoluteMod(newMods[id]);
+			}
 
+			// Ditch any mods that were specifically removed
+			if (mods.value && removed) {
+				for (const id of Object.keys(removed)) {
+					if (mods.value[id]) delete mods.value[id];
+				}
+			}
+
+			// Mark the mods as loaded
 			hasLoaded.value = true;
-			console.debug('Mods loaded', mods);
-			info(`${Object.keys(mods).length} mods loaded`);
+			console.debug('Mods loaded', newMods);
+			info(`${Object.keys(newMods).length} mods loaded`);
 
-			this.$patch({ mods });
-			return mods;
+			this.$patch({ mods: newMods });
+			return newMods;
 		} catch (err) {
 			error(`Error loading mods: ${err}`);
 
+			// Alert the user to the failure
 			if (alert) {
 				message(`Error loading mod list:\n${err}`, {
 					title: 'Error loading mods',
@@ -59,23 +74,36 @@ export const useModStore = defineStore('mods', () => {
 	 * @returns {Object} {@link ResoluteMod}s mapped by their ID
 	 */
 	async function loadInstalled() {
+		// Ensure we're not already loading the installed mods elsewhere
 		if (loadingInstalled.value) {
 			throw new Error('Already loading installed mods.');
 		}
 		loadingInstalled.value = true;
 
 		try {
+			// Load the installed mods from the backend
 			await info('Requesting installed mod load');
-			const mods = await invoke('load_installed_mods');
-			for (const id of Object.keys(mods)) mods[id] = new ResoluteMod(mods[id]);
+			const { mods: newMods, removed } = await invoke('load_installed_mods');
+			for (const id of Object.keys(newMods)) {
+				newMods[id] = new ResoluteMod(newMods[id]);
+			}
 
+			// Ditch any mods that were specifically removed
+			if (mods.value && removed) {
+				for (const id of Object.keys(removed)) {
+					if (mods.value[id]) delete mods.value[id];
+				}
+			}
+
+			// Mark the installed mods as loaded
 			hasLoadedInstalled.value = true;
-			console.debug('Installed mods loaded', mods);
-			info(`${Object.keys(mods).length} installed mods loaded`);
+			console.debug('Installed mods loaded', newMods);
+			info(`${Object.keys(newMods).length} installed mods loaded`);
 
-			this.$patch({ mods });
-			return mods;
+			this.$patch({ mods: newMods });
+			return newMods;
 		} catch (err) {
+			// Alert the user to the failure
 			error(`Error loading installed mods: ${err}`);
 			message(`Error loading installed mod list:\n${err}`, {
 				title: 'Error loading mods',

--- a/ui/src/structs/mod.js
+++ b/ui/src/structs/mod.js
@@ -84,6 +84,14 @@ export class ResoluteMod {
 	}
 
 	/**
+	 * Whether this is an unrecognized mod
+	 * @type {boolean}
+	 */
+	get isUnrecognized() {
+		return this.id.startsWith('dev.gawdl3y.resolute.unrecognized');
+	}
+
+	/**
 	 * Latest available version
 	 * @type {ModVersion}
 	 */
@@ -100,22 +108,23 @@ export class ResoluteMod {
 	}
 
 	/**
-	 * A number for the version status, for the purposes of sorting.
-	 * 0 for update available, 1 for installed, 2 for not installed
-	 * @type {number}
-	 */
-	get sortableVersionStatus() {
-		return this.hasUpdate ? 0 : this.installedVersion ? 1 : 2;
-	}
-
-	/**
 	 * A CSS class to use for the version text.
 	 * text-success if installed and up-to-date, text-warning if there is an update available, nothing otherwise.
 	 * @type {string}
 	 */
 	get versionTextClass() {
 		if (!this.installedVersion) return '';
+		if (this.isUnrecognized) return 'text-blue';
 		return this.hasUpdate ? 'text-warning' : 'text-success';
+	}
+
+	/**
+	 * A number for the version status, for the purposes of sorting.
+	 * 0 for update available, 1 for installed, 2 for not installed
+	 * @type {number}
+	 */
+	get sortableVersionStatus() {
+		return this.hasUpdate ? 0 : this.installedVersion ? 1 : 2;
 	}
 
 	toJSON() {
@@ -193,6 +202,22 @@ export class ModVersion {
 		 * @type {?string}
 		 */
 		this.releaseUrl = data.releaseUrl;
+	}
+
+	/**
+	 * Whether this version is for an unrecognized artifact
+	 * @type {boolean}
+	 */
+	get isUnrecognized() {
+		return this.semver === '0.0.0-unknown';
+	}
+
+	/**
+	 * Text label for the version
+	 * @type {string}
+	 */
+	get label() {
+		return this.isUnrecognized ? 'Unknown' : this.semver;
 	}
 }
 


### PR DESCRIPTION
- [x] Discover unrecognized mods
- [x] Discover unrecognized artifacts for known mods
- [x] Display unrecognized mods distinguishably
- [x] Don't allow reinstallation of unrecognized mods/versions
- [x] Fix unrecognized versions for known mods disappearing from installed list
- [x] Replace unrecognized mod with a recognized one with the same artifact filename once encountered
- ~~Remove unrecognized version from installed mods in database once replaced with a known version~~  
Unnecessary since discovery will replace the unrecognized version in the versions map if it ever occurs again

![image](https://github.com/Gawdl3y/Resolute/assets/279900/1211e768-373a-4771-baba-08622394d837)

Closes #104 