### PR TITLE
Don't show file drop hint when dragging links around in authoring tools

### DIFF
--- a/ui/src/components/pages/ModAuthorToolsPage.vue
+++ b/ui/src/components/pages/ModAuthorToolsPage.vue
@@ -70,7 +70,9 @@ onMounted(async () => {
 
 	unlistenToFileHover = await listen('tauri://file-drop-hover', (evt) => {
 		console.debug('File hover received', evt);
-		fileHovering.value = true;
+		if (evt.payload && evt.payload.length > 0) {
+			fileHovering.value = true;
+		}
 	});
 
 	unlistenToFileCancelled = await listen(


### PR DESCRIPTION
This fixes the file drop hint ("Calculate checksum...") being displayed when dragging links (such as a sidebar nav item) around on the mod authoring tools page.

## Context
All dragged items trigger file hover events, but the event only has a payload when it's actually a file being dragged.