### PR TITLE
Revert "Don't force NSIS installer from updater"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
       releaseBody: ${{ needs.changelog.outputs.changelog }}
       releaseDraft: true
       includeUpdaterJson: true
+      updaterJsonPreferNsis: true
     secrets:
       updaterKey: ${{ secrets.TAURI_UPDATER_KEY }}
       updaterKeyPassword: ${{ secrets.TAURI_UPDATER_KEY_PASSWORD }}


### PR DESCRIPTION
This reverts commit 1dca1ba01f336f051a9d9d8c53f01443508967fc.

This was causing the updater to instead prefer the MSI, which leads to less-than-desirable behaviour when the NSIS version was in use.