### PR TITLE
Extract Tauri commands into semi-organized modules

### DIFF
--- a/crates/tauri-app/src/commands/discover.rs
+++ b/crates/tauri-app/src/commands/discover.rs
@@ -1,0 +1,54 @@
+use log::{error, info};
+use resolute::{discover, manager::ModManager, mods::ResoluteModMap};
+use tauri::AppHandle;
+use tokio::sync::Mutex;
+
+use crate::{build_manifest_config, settings};
+
+/// Looks for a possible Resonite path
+#[tauri::command]
+pub(crate) async fn discover_resonite_path() -> Result<Option<String>, String> {
+	let path = tauri::async_runtime::spawn_blocking(|| discover::discover_resonite(None))
+		.await
+		.map_err(|err| {
+			error!("Unable to spawn blocking task for Resonite path discovery: {}", err);
+			format!("Unable to spawn blocking task for Resonite path discovery: {}", err)
+		})?
+		.map_err(|err| {
+			error!("Unable to discover Resonite path: {}", err);
+			format!("Unable to discover Resonite path: {}", err)
+		})?;
+
+	match path {
+		Some(path) => path.to_str().map(|path| Some(path.to_owned())).ok_or_else(|| {
+			error!("Unable to convert discovered Resonite path ({:?}) to a String", path);
+			"Unable to convert discovered Resonite path to a String".to_owned()
+		}),
+		None => Ok(None),
+	}
+}
+
+/// Discovers installed mods
+#[tauri::command]
+pub(crate) async fn discover_installed_mods(
+	app: AppHandle,
+	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
+) -> Result<ResoluteModMap, String> {
+	let mut manager = manager.lock().await;
+
+	// Update the Resonite path in case the setting has changed
+	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
+	manager.set_base_dest(resonite_path);
+
+	// Run the discovery
+	info!("Discovering installed mods");
+	let mods = manager
+		.discover_installed_mods(build_manifest_config(&app)?)
+		.await
+		.map_err(|err| {
+			error!("Unable to discover installed mods: {}", err);
+			format!("Unable to discover installed mods: {}", err)
+		})?;
+
+	Ok(mods)
+}

--- a/crates/tauri-app/src/commands/manager.rs
+++ b/crates/tauri-app/src/commands/manager.rs
@@ -1,0 +1,147 @@
+use log::{error, info};
+use resolute::{
+	manager::{LoadedMods, ModManager},
+	mods::{ModVersion, ResoluteMod},
+};
+use tauri::AppHandle;
+use tokio::sync::Mutex;
+
+use crate::{build_manifest_config, settings};
+
+/// Loads all mods from the manager
+#[tauri::command]
+pub(crate) async fn load_all_mods(
+	app: AppHandle,
+	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
+	bypass_cache: bool,
+) -> Result<LoadedMods, String> {
+	let mods = manager
+		.lock()
+		.await
+		.get_all_mods(build_manifest_config(&app)?, bypass_cache)
+		.await
+		.map_err(|err| format!("Unable to get all mods from manager: {}", err))?;
+	Ok(mods)
+}
+
+/// Loads installed mods from the manager
+#[tauri::command]
+pub(crate) async fn load_installed_mods(
+	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
+) -> Result<LoadedMods, String> {
+	let mods = manager
+		.lock()
+		.await
+		.get_installed_mods()
+		.await
+		.map_err(|err| format!("Unable to get installed mods from manager: {}", err))?;
+	Ok(mods)
+}
+
+/// Installs a mod version
+#[tauri::command]
+pub(crate) async fn install_mod_version(
+	app: AppHandle,
+	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
+	rmod: ResoluteMod,
+	version: ModVersion,
+) -> Result<(), String> {
+	let mut manager = manager.lock().await;
+
+	// Update the Resonite path in case the setting has changed
+	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
+	manager.set_base_dest(resonite_path);
+
+	// Download the version
+	info!("Installing mod {} v{}", rmod.name, version.semver);
+	manager
+		.install_mod(&rmod, version.semver.to_string(), |_, _| {})
+		.await
+		.map_err(|err| {
+			error!("Failed to download mod {} v{}: {}", rmod.name, version.semver, err);
+			format!("Unable to download mod version: {}", err)
+		})?;
+
+	info!("Successfully installed mod {} v{}", rmod.name, version.semver);
+	Ok(())
+}
+
+/// Updates a mod to a new version
+#[tauri::command]
+pub(crate) async fn replace_mod_version(
+	app: AppHandle,
+	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
+	rmod: ResoluteMod,
+	version: ModVersion,
+) -> Result<(), String> {
+	let mut manager = manager.lock().await;
+
+	// Update the Resonite path in case the setting has changed
+	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
+	manager.set_base_dest(resonite_path);
+
+	// Ensure the mod is installed
+	let old_version = match &rmod.installed_version {
+		Some(version) => version,
+		None => {
+			return Err(format!(
+				"Mod {} doesn't have an installed version to replace",
+				rmod.name
+			))
+		}
+	};
+
+	// Update the mod to the given version
+	info!("Replacing mod {} v{} with v{}", rmod.name, old_version, version.semver);
+	manager
+		.update_mod(&rmod, version.semver.to_string(), |_, _| {})
+		.await
+		.map_err(|err| {
+			error!(
+				"Failed to replace mod {} v{} with v{}: {}",
+				rmod.name, old_version, version.semver, err
+			);
+			format!("Unable to replace mod version: {}", err)
+		})?;
+
+	info!(
+		"Successfully replaced mod {} v{} with v{}",
+		rmod.name, old_version, version.semver
+	);
+	Ok(())
+}
+
+/// Uninstalls a mod
+#[tauri::command]
+pub(crate) async fn uninstall_mod(
+	app: AppHandle,
+	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
+	rmod: ResoluteMod,
+) -> Result<(), String> {
+	let mut manager = manager.lock().await;
+
+	// Update the Resonite path in case the setting has changed
+	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
+	manager.set_base_dest(resonite_path);
+
+	// Ensure the mod is installed
+	let old_version = match &rmod.installed_version {
+		Some(version) => version,
+		None => {
+			return Err(format!(
+				"Mod {} doesn't have an installed version to uninstall",
+				rmod.name
+			))
+		}
+	};
+
+	// Uninstall the mod
+	info!("Uninstalling mod {} v{}", rmod.name, old_version);
+	manager.uninstall_mod(&rmod).await.map_err(|err| {
+		error!("Failed to uninstall mod {} v{}: {}", rmod.name, old_version, err);
+		format!("Unable to uninstall mod: {}", err)
+	})?;
+
+	info!("Successfully uninstalled mod {} v{}", rmod.name, old_version);
+	Ok(())
+}

--- a/crates/tauri-app/src/commands/mod.rs
+++ b/crates/tauri-app/src/commands/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod discover;
+pub(crate) mod manager;
+pub(crate) mod settings;
+pub(crate) mod system;

--- a/crates/tauri-app/src/commands/settings.rs
+++ b/crates/tauri-app/src/commands/settings.rs
@@ -1,0 +1,30 @@
+use log::info;
+use resolute::manager::ModManager;
+use tauri::AppHandle;
+use tokio::sync::Mutex;
+
+use crate::{build_http_client, settings};
+
+/// Ensures a change to the Resonite path setting is propagated to the manager
+#[tauri::command]
+pub(crate) async fn resonite_path_changed(
+	app: AppHandle,
+	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
+) -> Result<(), String> {
+	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
+	manager.lock().await.set_base_dest(&resonite_path);
+	info!("Changed manager's base destination to {}", resonite_path);
+	Ok(())
+}
+
+/// Ensures a change to the connection timeout setting is propagated to the manager
+#[tauri::command]
+pub(crate) async fn connect_timeout_changed(
+	app: AppHandle,
+	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
+) -> Result<(), String> {
+	let http_client = build_http_client(&app).map_err(|err| err.to_string())?;
+	manager.lock().await.set_http_client(http_client);
+	info!("Changed manager's HTTP client for connectTimeout setting change");
+	Ok(())
+}

--- a/crates/tauri-app/src/commands/system.rs
+++ b/crates/tauri-app/src/commands/system.rs
@@ -1,0 +1,101 @@
+use itertools::Itertools;
+use log::{error, info};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Window};
+use tokio::io::AsyncReadExt;
+
+use crate::settings;
+
+/// Sets the requesting window's visibility to shown
+#[tauri::command]
+pub(crate) fn show_window(window: Window) -> Result<(), String> {
+	window.show().map_err(|err| format!("Unable to show window: {}", err))?;
+	Ok(())
+}
+
+/// Verifies the Resonite path specified in the settings store exists
+#[tauri::command]
+pub(crate) async fn verify_resonite_path(app: AppHandle) -> Result<bool, String> {
+	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
+	tokio::fs::try_exists(resonite_path)
+		.await
+		.map_err(|err| err.to_string())
+}
+
+/// Calculates the SHA-256 checksum of a file
+#[tauri::command]
+pub(crate) async fn hash_file(path: String) -> Result<String, String> {
+	// Verify the path given is a file
+	let meta = tokio::fs::metadata(&path)
+		.await
+		.map_err(|err| format!("Unable to read metadata of path: {}", err))?;
+	if !meta.is_file() {
+		return Err("The supplied path isn't a file. Hashing of directories isn't supported.".to_owned());
+	}
+
+	// Hash the file
+	info!("Hashing file {}", path);
+	let file = path.clone();
+	let digest = tauri::async_runtime::spawn_blocking(move || {
+		let mut hasher = Sha256::new();
+		let mut file = std::fs::File::open(file).map_err(|err| format!("Error opening file: {}", err))?;
+		std::io::copy(&mut file, &mut hasher).map_err(|err| format!("Error hashing file: {}", err))?;
+		Ok::<_, String>(hasher.finalize())
+	})
+	.await
+	.map_err(|err| {
+		error!("Error spawning hashing task for file {}: {}", path, err);
+		format!("Error spawning hashing task: {}", err)
+	})?
+	.map_err(|err| {
+		error!("Error hashing file {}: {}", path, err);
+		format!("Error hashing file: {}", err)
+	})?;
+
+	let hash = format!("{:x}", digest);
+	info!("Finished hashing file {}: {}", path, hash);
+	Ok(hash)
+}
+
+/// Gets the log file content from this session
+#[tauri::command]
+pub(crate) async fn get_session_log(app: AppHandle) -> Result<String, String> {
+	// Figure out the path to the log file
+	let resolver = app.path_resolver();
+	let mut log_path = resolver.app_log_dir().ok_or("Unable to get log directory")?;
+	log_path.push(format!("{}.log", app.package_info().name));
+
+	let log = {
+		// Open and read the file
+		let mut file = tokio::fs::File::open(log_path)
+			.await
+			.map_err(|err| format!("Error opening log file: {}", err))?;
+		let mut log = String::new();
+		file.read_to_string(&mut log)
+			.await
+			.map_err(|err| format!("Error reading log file contents: {}", err))?;
+
+		// Get only the log lines after the most recent initializing line
+		log.lines()
+			.rev()
+			.take_while_inclusive(|line| !line.ends_with("initializing"))
+			.fold(String::new(), |mut acc, line| {
+				acc.insert(0, '\n');
+				acc.insert_str(0, line);
+				acc
+			})
+	};
+
+	Ok(log)
+}
+
+/// Opens the app's log directory in the system file browser
+#[tauri::command]
+pub(crate) async fn open_log_dir(app: AppHandle) -> Result<(), String> {
+	let path = app
+		.path_resolver()
+		.app_log_dir()
+		.ok_or_else(|| "Unable to get log directory".to_owned())?;
+	opener::open(path).map_err(|err| format!("Unable to open log directory: {}", err))?;
+	Ok(())
+}

--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -4,25 +4,19 @@
 use std::{io, time::Duration};
 
 use anyhow::{anyhow, Context};
-use itertools::Itertools;
 use log::{debug, error, info, warn};
 use native_db::DatabaseBuilder;
 use once_cell::sync::Lazy;
-use resolute::{
-	db::ResoluteDatabase,
-	discover,
-	manager::{LoadedMods, ModManager},
-	manifest,
-	mods::{ModVersion, ResoluteMod, ResoluteModMap},
-};
-use sha2::{Digest, Sha256};
-use tauri::{AppHandle, Manager, Window, WindowEvent};
+use resolute::{db::ResoluteDatabase, discover, manager::ModManager, manifest};
+use tauri::{AppHandle, Manager, WindowEvent};
 use tauri_plugin_log::LogTarget;
 use tauri_plugin_window_state::StateFlags;
-use tokio::{fs, io::AsyncReadExt, join, sync::Mutex};
+use tokio::{fs, join, sync::Mutex};
 
+mod commands;
 mod settings;
 
+/// Lazily-initialized database builder for the Resolute DB
 static mut DB_BUILDER: Lazy<DatabaseBuilder> = Lazy::new(DatabaseBuilder::new);
 
 fn main() -> anyhow::Result<()> {
@@ -66,20 +60,20 @@ fn main() -> anyhow::Result<()> {
 		)
 		.plugin(tauri_plugin_store::Builder::default().build())
 		.invoke_handler(tauri::generate_handler![
-			show_window,
-			load_all_mods,
-			load_installed_mods,
-			install_mod_version,
-			replace_mod_version,
-			uninstall_mod,
-			discover_resonite_path,
-			discover_installed_mods,
-			verify_resonite_path,
-			hash_file,
-			get_session_log,
-			open_log_dir,
-			resonite_path_changed,
-			connect_timeout_changed,
+			commands::manager::load_all_mods,
+			commands::manager::load_installed_mods,
+			commands::manager::install_mod_version,
+			commands::manager::replace_mod_version,
+			commands::manager::uninstall_mod,
+			commands::discover::discover_resonite_path,
+			commands::discover::discover_installed_mods,
+			commands::system::show_window,
+			commands::system::verify_resonite_path,
+			commands::system::hash_file,
+			commands::system::get_session_log,
+			commands::system::open_log_dir,
+			commands::settings::resonite_path_changed,
+			commands::settings::connect_timeout_changed,
 		])
 		.setup(|app| {
 			let window = app.get_window("main").ok_or("unable to get main window")?;
@@ -230,8 +224,22 @@ async fn autodiscover_resonite_path(app: AppHandle) -> Result<(), anyhow::Error>
 	Ok(())
 }
 
+/// Builds the error window for a given error, then closes the main window
+fn build_error_window(app: AppHandle, err: anyhow::Error) {
+	let init_script = format!("globalThis.error = `{:?}`;", err);
+	tauri::WindowBuilder::new(&app, "error", tauri::WindowUrl::App("error.html".into()))
+		.title("Resolute")
+		.center()
+		.resizable(false)
+		.visible(false)
+		.initialization_script(&init_script)
+		.build()
+		.expect("Error occurred while initializing and the error window couldn't be displayed");
+	let _ = app.get_window("main").expect("unable to get main window").close();
+}
+
 /// Builds a manifest config that takes the user-configured settings into account
-fn build_manifest_config(app: &AppHandle) -> Result<manifest::Config, String> {
+pub(crate) fn build_manifest_config(app: &AppHandle) -> Result<manifest::Config, String> {
 	// Build the base config
 	let mut config = manifest::Config {
 		cache_file_path: Some(
@@ -255,7 +263,7 @@ fn build_manifest_config(app: &AppHandle) -> Result<manifest::Config, String> {
 }
 
 /// Builds an HTTP client that takes the user-configured settings into account
-fn build_http_client(app: &AppHandle) -> Result<reqwest::Client, anyhow::Error> {
+pub(crate) fn build_http_client(app: &AppHandle) -> Result<reqwest::Client, anyhow::Error> {
 	let connect_timeout: f32 = settings::get(app, "connectTimeout")?.unwrap_or(10f32);
 	debug!("Building HTTP client, connectTimeout = {}s", connect_timeout);
 
@@ -266,319 +274,7 @@ fn build_http_client(app: &AppHandle) -> Result<reqwest::Client, anyhow::Error> 
 		.context("Unable to build HTTP client")
 }
 
-/// Builds the error window for a given error, then closes the main window
-fn build_error_window(app: AppHandle, err: anyhow::Error) {
-	let init_script = format!("globalThis.error = `{:?}`;", err);
-	tauri::WindowBuilder::new(&app, "error", tauri::WindowUrl::App("error.html".into()))
-		.title("Resolute")
-		.center()
-		.resizable(false)
-		.visible(false)
-		.initialization_script(&init_script)
-		.build()
-		.expect("Error occurred while initializing and the error window couldn't be displayed");
-	let _ = app.get_window("main").expect("unable to get main window").close();
-}
-
-/// Sets the requesting window's visibility to shown
-#[tauri::command]
-fn show_window(window: Window) -> Result<(), String> {
-	window.show().map_err(|err| format!("Unable to show window: {}", err))?;
-	Ok(())
-}
-
-/// Loads all mods from the manager
-#[tauri::command]
-async fn load_all_mods(
-	app: AppHandle,
-	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
-	bypass_cache: bool,
-) -> Result<LoadedMods, String> {
-	let mods = manager
-		.lock()
-		.await
-		.get_all_mods(build_manifest_config(&app)?, bypass_cache)
-		.await
-		.map_err(|err| format!("Unable to get all mods from manager: {}", err))?;
-	Ok(mods)
-}
-
-/// Loads installed mods from the manager
-#[tauri::command]
-async fn load_installed_mods(manager: tauri::State<'_, Mutex<ModManager<'_>>>) -> Result<LoadedMods, String> {
-	let mods = manager
-		.lock()
-		.await
-		.get_installed_mods()
-		.await
-		.map_err(|err| format!("Unable to get installed mods from manager: {}", err))?;
-	Ok(mods)
-}
-
-/// Installs a mod version
-#[tauri::command]
-async fn install_mod_version(
-	app: AppHandle,
-	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
-	rmod: ResoluteMod,
-	version: ModVersion,
-) -> Result<(), String> {
-	let mut manager = manager.lock().await;
-
-	// Update the Resonite path in case the setting has changed
-	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
-	manager.set_base_dest(resonite_path);
-
-	// Download the version
-	info!("Installing mod {} v{}", rmod.name, version.semver);
-	manager
-		.install_mod(&rmod, version.semver.to_string(), |_, _| {})
-		.await
-		.map_err(|err| {
-			error!("Failed to download mod {} v{}: {}", rmod.name, version.semver, err);
-			format!("Unable to download mod version: {}", err)
-		})?;
-
-	info!("Successfully installed mod {} v{}", rmod.name, version.semver);
-	Ok(())
-}
-
-/// Updates a mod to a new version
-#[tauri::command]
-async fn replace_mod_version(
-	app: AppHandle,
-	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
-	rmod: ResoluteMod,
-	version: ModVersion,
-) -> Result<(), String> {
-	let mut manager = manager.lock().await;
-
-	// Update the Resonite path in case the setting has changed
-	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
-	manager.set_base_dest(resonite_path);
-
-	// Ensure the mod is installed
-	let old_version = match &rmod.installed_version {
-		Some(version) => version,
-		None => {
-			return Err(format!(
-				"Mod {} doesn't have an installed version to replace",
-				rmod.name
-			))
-		}
-	};
-
-	// Update the mod to the given version
-	info!("Replacing mod {} v{} with v{}", rmod.name, old_version, version.semver);
-	manager
-		.update_mod(&rmod, version.semver.to_string(), |_, _| {})
-		.await
-		.map_err(|err| {
-			error!(
-				"Failed to replace mod {} v{} with v{}: {}",
-				rmod.name, old_version, version.semver, err
-			);
-			format!("Unable to replace mod version: {}", err)
-		})?;
-
-	info!(
-		"Successfully replaced mod {} v{} with v{}",
-		rmod.name, old_version, version.semver
-	);
-	Ok(())
-}
-
-/// Uninstalls a mod
-#[tauri::command]
-async fn uninstall_mod(
-	app: AppHandle,
-	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
-	rmod: ResoluteMod,
-) -> Result<(), String> {
-	let mut manager = manager.lock().await;
-
-	// Update the Resonite path in case the setting has changed
-	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
-	manager.set_base_dest(resonite_path);
-
-	// Ensure the mod is installed
-	let old_version = match &rmod.installed_version {
-		Some(version) => version,
-		None => {
-			return Err(format!(
-				"Mod {} doesn't have an installed version to uninstall",
-				rmod.name
-			))
-		}
-	};
-
-	// Uninstall the mod
-	info!("Uninstalling mod {} v{}", rmod.name, old_version);
-	manager.uninstall_mod(&rmod).await.map_err(|err| {
-		error!("Failed to uninstall mod {} v{}: {}", rmod.name, old_version, err);
-		format!("Unable to uninstall mod: {}", err)
-	})?;
-
-	info!("Successfully uninstalled mod {} v{}", rmod.name, old_version);
-	Ok(())
-}
-
-/// Looks for a possible Resonite path
-#[tauri::command]
-async fn discover_resonite_path() -> Result<Option<String>, String> {
-	let path = tauri::async_runtime::spawn_blocking(|| discover::discover_resonite(None))
-		.await
-		.map_err(|err| {
-			error!("Unable to spawn blocking task for Resonite path discovery: {}", err);
-			format!("Unable to spawn blocking task for Resonite path discovery: {}", err)
-		})?
-		.map_err(|err| {
-			error!("Unable to discover Resonite path: {}", err);
-			format!("Unable to discover Resonite path: {}", err)
-		})?;
-
-	match path {
-		Some(path) => path.to_str().map(|path| Some(path.to_owned())).ok_or_else(|| {
-			error!("Unable to convert discovered Resonite path ({:?}) to a String", path);
-			"Unable to convert discovered Resonite path to a String".to_owned()
-		}),
-		None => Ok(None),
-	}
-}
-
-/// Discovers installed mods
-#[tauri::command]
-async fn discover_installed_mods(
-	app: AppHandle,
-	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
-) -> Result<ResoluteModMap, String> {
-	let mut manager = manager.lock().await;
-
-	// Update the Resonite path in case the setting has changed
-	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
-	manager.set_base_dest(resonite_path);
-
-	// Run the discovery
-	info!("Discovering installed mods");
-	let mods = manager
-		.discover_installed_mods(build_manifest_config(&app)?)
-		.await
-		.map_err(|err| {
-			error!("Unable to discover installed mods: {}", err);
-			format!("Unable to discover installed mods: {}", err)
-		})?;
-
-	Ok(mods)
-}
-
-/// Verifies the Resonite path specified in the settings store exists
-#[tauri::command]
-async fn verify_resonite_path(app: AppHandle) -> Result<bool, String> {
-	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
-	tokio::fs::try_exists(resonite_path)
-		.await
-		.map_err(|err| err.to_string())
-}
-
-/// Calculates the SHA-256 checksum of a file
-#[tauri::command]
-async fn hash_file(path: String) -> Result<String, String> {
-	// Verify the path given is a file
-	let meta = fs::metadata(&path)
-		.await
-		.map_err(|err| format!("Unable to read metadata of path: {}", err))?;
-	if !meta.is_file() {
-		return Err("The supplied path isn't a file. Hashing of directories isn't supported.".to_owned());
-	}
-
-	// Hash the file
-	info!("Hashing file {}", path);
-	let file = path.clone();
-	let digest = tauri::async_runtime::spawn_blocking(move || {
-		let mut hasher = Sha256::new();
-		let mut file = std::fs::File::open(file).map_err(|err| format!("Error opening file: {}", err))?;
-		io::copy(&mut file, &mut hasher).map_err(|err| format!("Error hashing file: {}", err))?;
-		Ok::<_, String>(hasher.finalize())
-	})
-	.await
-	.map_err(|err| {
-		error!("Error spawning hashing task for file {}: {}", path, err);
-		format!("Error spawning hashing task: {}", err)
-	})?
-	.map_err(|err| {
-		error!("Error hashing file {}: {}", path, err);
-		format!("Error hashing file: {}", err)
-	})?;
-
-	let hash = format!("{:x}", digest);
-	info!("Finished hashing file {}: {}", path, hash);
-	Ok(hash)
-}
-
-/// Gets the log file content from this session
-#[tauri::command]
-async fn get_session_log(app: AppHandle) -> Result<String, String> {
-	// Figure out the path to the log file
-	let resolver = app.path_resolver();
-	let mut log_path = resolver.app_log_dir().ok_or("Unable to get log directory")?;
-	log_path.push(format!("{}.log", app.package_info().name));
-
-	let log = {
-		// Open and read the file
-		let mut file = fs::File::open(log_path)
-			.await
-			.map_err(|err| format!("Error opening log file: {}", err))?;
-		let mut log = String::new();
-		file.read_to_string(&mut log)
-			.await
-			.map_err(|err| format!("Error reading log file contents: {}", err))?;
-
-		// Get only the log lines after the most recent initializing line
-		log.lines()
-			.rev()
-			.take_while_inclusive(|line| !line.ends_with("initializing"))
-			.fold(String::new(), |mut acc, line| {
-				acc.insert(0, '\n');
-				acc.insert_str(0, line);
-				acc
-			})
-	};
-
-	Ok(log)
-}
-
-/// Opens the app's log directory in the system file browser
-#[tauri::command]
-async fn open_log_dir(app: AppHandle) -> Result<(), String> {
-	let path = app
-		.path_resolver()
-		.app_log_dir()
-		.ok_or_else(|| "Unable to get log directory".to_owned())?;
-	opener::open(path).map_err(|err| format!("Unable to open log directory: {}", err))?;
-	Ok(())
-}
-
-/// Ensures a change to the Resonite path setting is propagated to the manager
-#[tauri::command]
-async fn resonite_path_changed(app: AppHandle, manager: tauri::State<'_, Mutex<ModManager<'_>>>) -> Result<(), String> {
-	let resonite_path: String = settings::require(&app, "resonitePath").map_err(|err| err.to_string())?;
-	manager.lock().await.set_base_dest(&resonite_path);
-	info!("Changed manager's base destination to {}", resonite_path);
-	Ok(())
-}
-
-/// Ensures a change to the connection timeout setting is propagated to the manager
-#[tauri::command]
-async fn connect_timeout_changed(
-	app: AppHandle,
-	manager: tauri::State<'_, Mutex<ModManager<'_>>>,
-) -> Result<(), String> {
-	let http_client = build_http_client(&app).map_err(|err| err.to_string())?;
-	manager.lock().await.set_http_client(http_client);
-	info!("Changed manager's HTTP client for connectTimeout setting change");
-	Ok(())
-}
-
+/// Payload for a single-instance event
 #[derive(Clone, serde::Serialize)]
 struct Payload {
 	args: Vec<String>,


### PR DESCRIPTION
Splits all of the Tauri commands out into modules.
No functional changes, just some reorganization of existing code.