### PR TITLE
Add progress bar functionality to AppHeader

### DIFF
--- a/ui/src/components/AppHeader.vue
+++ b/ui/src/components/AppHeader.vue
@@ -15,6 +15,15 @@
 		<template v-if="$slots.extension" #extension>
 			<slot name="extension" />
 		</template>
+
+		<v-progress-linear
+			v-model="progress"
+			:active="loading"
+			:indeterminate="indeterminate"
+			:stream="stream"
+			absolute
+			location="bottom"
+		/>
 	</v-app-bar>
 </template>
 
@@ -23,7 +32,13 @@ import { ref, onMounted, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { mdiArrowLeft } from '@mdi/js';
 
-defineProps({ title: { type: String, required: true } });
+const progress = defineModel('progress', { type: Number, default: -1 });
+defineProps({
+	title: { type: String, required: true },
+	loading: { type: Boolean, default: false },
+	indeterminate: { type: Boolean, default: false },
+	stream: { type: Boolean, default: false },
+});
 
 const router = useRouter();
 const canGoBack = ref(Boolean(window.history.state.back));

--- a/ui/src/components/pages/SessionLogPage.vue
+++ b/ui/src/components/pages/SessionLogPage.vue
@@ -1,5 +1,5 @@
 <template>
-	<AppHeader title="Console" :loading="loading">
+	<AppHeader title="Console" :loading="loading" :indeterminate="loading">
 		<template #actions>
 			<v-tooltip text="Open log folder" :open-delay="500">
 				<template #activator="{ props }">


### PR DESCRIPTION
Adds basic progress bar functionality to the AppHeader component, which currently only the console page relies on.