### PR TITLE
Separate database/settings/logs for debug builds

### DIFF
--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -100,7 +100,18 @@ fn main() -> anyhow::Result<()> {
 
 			Ok(())
 		})
-		.run(tauri::generate_context!())
+		.run(
+			#[cfg(debug_assertions)]
+			{
+				let mut context = tauri::generate_context!();
+				context.config_mut().tauri.bundle.identifier += ".debug";
+				context
+			},
+			#[cfg(not(debug_assertions))]
+			{
+				tauri::generate_context!()
+			},
+		)
 		.with_context(|| "Unable to initialize Tauri application")?;
 
 	Ok(())

--- a/ui/src/components/pages/DashboardPage.vue
+++ b/ui/src/components/pages/DashboardPage.vue
@@ -7,7 +7,7 @@
 		<v-sheet rounded elevation="4" class="w-75 pa-4" style="max-width: 32em">
 			<div class="d-flex justify-space-between mb-3">
 				<h2 class="text-h5">What the HECK is Resolute?</h2>
-				<p v-if="version" class="text-body-1 text-disabled">v{{ version }}</p>
+				<p class="text-body-1 text-disabled">v{{ app.version.value }}</p>
 			</div>
 
 			<p class="mb-3 text-body-1">
@@ -43,14 +43,10 @@
 </template>
 
 <script setup>
-import { ref, onBeforeMount } from 'vue';
-import { getVersion } from '@tauri-apps/api/app';
 import { mdiSourceBranch } from '@mdi/js';
+
+import useApp from '../../composables/app';
 import AppHeader from '../AppHeader.vue';
 
-const version = ref(null);
-
-onBeforeMount(async () => {
-	version.value = await getVersion();
-});
+const app = useApp();
 </script>

--- a/ui/src/composables/app.js
+++ b/ui/src/composables/app.js
@@ -1,0 +1,38 @@
+import { ref } from 'vue';
+import { invoke } from '@tauri-apps/api';
+
+let name = ref('');
+let identifier = ref('');
+let version = ref('');
+let tauriVersion = ref('');
+let debug = ref(false);
+
+export function useApp() {
+	/**
+	 * Retrieves the app info from the backend
+	 * @returns {Object}
+	 */
+	async function init() {
+		const info = await invoke('get_app_info');
+		console.debug('App information retrieved:', info);
+
+		name.value = info.name;
+		identifier.value = info.identifier;
+		version.value = info.version;
+		tauriVersion.value = info.tauriVersion;
+		debug.value = info.debug;
+
+		return info;
+	}
+
+	return {
+		init,
+		name,
+		identifier,
+		version,
+		tauriVersion,
+		debug,
+	};
+}
+
+export default useApp;


### PR DESCRIPTION
- Appends ".debug" to the bundle identifier at runtime for debug builds, resulting in all data for the app being separated from release builds
- Appends "(debug)" to the main window title for debug builds
- Extracts app information logic into its own composable on the frontend and a command on the backend
- Makes the frontend use the debug status from the backend for any debug mode decisions (i.e. text selection and context menu disabling)
- Enables logging to a single file for debug builds