### PR TITLE
Use v-bind same-name shorthand syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"eslint": "^8.56.0",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-prettier-vue": "^5.0.0",
-				"eslint-plugin-vue": "^9.19.2",
+				"eslint-plugin-vue": "^9.20.0",
 				"prettier": "3.1.1",
 				"vite": "^5.0.11",
 				"vite-plugin-vuetify": "^2.0.1"
@@ -1396,9 +1396,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-vue": {
-			"version": "9.19.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.19.2.tgz",
-			"integrity": "sha512-CPDqTOG2K4Ni2o4J5wixkLVNwgctKXFu6oBpVJlpNq7f38lh9I80pRTouZSJ2MAebPJlINU/KTFSXyQfBUlymA==",
+			"version": "9.20.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.20.0.tgz",
+			"integrity": "sha512-9/DV5CM7ItfgWmXjL6j3zyDtVTrslYdnEm+rnYNajdElx17b3erxi/Wc6FY7t3BQ6dgo0t/UBpgiWCOKtJyN8Q==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
@@ -1406,7 +1406,7 @@
 				"nth-check": "^2.1.1",
 				"postcss-selector-parser": "^6.0.13",
 				"semver": "^7.5.4",
-				"vue-eslint-parser": "^9.3.1",
+				"vue-eslint-parser": "^9.4.0",
 				"xml-name-validator": "^4.0.0"
 			},
 			"engines": {
@@ -2560,9 +2560,9 @@
 			}
 		},
 		"node_modules/vue-eslint-parser": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.2.tgz",
-			"integrity": "sha512-q7tWyCVaV9f8iQyIA5Mkj/S6AoJ9KBN8IeUSf3XEmBrOtxOZnfTg5s4KClbZBCK3GtnT/+RyCLZyDHuZwTuBjg==",
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.0.tgz",
+			"integrity": "sha512-7KsNBb6gHFA75BtneJsoK/dbZ281whUIwFYdQxA68QrCrGMXYzUMbPDHGcOQ0OocIVKrWSKWXZ4mL7tonCXoUw==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -462,13 +462,13 @@
 			"integrity": "sha512-unZYfjXts55DQyODz0I9DzbSrS5DRKPNq9crJpNJe/Vy818bLnijprcJv3fvqwdDqTT0dRm2Fhk09QEIdtAc+Q=="
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.13",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
@@ -489,9 +489,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
 			"dev": true
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
@@ -540,9 +540,9 @@
 			}
 		},
 		"node_modules/@pkgr/core": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.0.tgz",
-			"integrity": "sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+			"integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
@@ -552,9 +552,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.3.tgz",
-			"integrity": "sha512-nvh9bB41vXEoKKvlWCGptpGt8EhrEwPQFDCY0VAto+R+qpSbaErPS3OjMZuXR8i/2UVw952Dtlnl2JFxH31Qvg==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.5.tgz",
+			"integrity": "sha512-idWaG8xeSRCfRq9KpRysDHJ/rEHBEXcHuJ82XY0yYFIWnLMjZv9vF/7DOq8djQ2n3Lk6+3qfSH8AqlmHlmi1MA==",
 			"cpu": [
 				"arm"
 			],
@@ -564,9 +564,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.3.tgz",
-			"integrity": "sha512-kffYCJ2RhDL1DlshLzYPyJtVeusHlA8Q1j6k6s4AEVKLq/3HfGa2ADDycLsmPo3OW83r4XtOPqRMbcFzFsEIzQ==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.5.tgz",
+			"integrity": "sha512-f14d7uhAMtsCGjAYwZGv6TwuS3IFaM4ZnGMUn3aCBgkcHAYErhV1Ad97WzBvS2o0aaDv4mVz+syiN0ElMyfBPg==",
 			"cpu": [
 				"arm64"
 			],
@@ -576,9 +576,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.3.tgz",
-			"integrity": "sha512-Fo7DR6Q9/+ztTyMBZ79+WJtb8RWZonyCgkBCjV51rW5K/dizBzImTW6HLC0pzmHaAevwM0jW1GtB5LCFE81mSw==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.5.tgz",
+			"integrity": "sha512-ndoXeLx455FffL68OIUrVr89Xu1WLzAG4n65R8roDlCoYiQcGGg6MALvs2Ap9zs7AHg8mpHtMpwC8jBBjZrT/w==",
 			"cpu": [
 				"arm64"
 			],
@@ -588,9 +588,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.3.tgz",
-			"integrity": "sha512-5HcxDF9fqHucIlTiw/gmMb3Qv23L8bLCg904I74Q2lpl4j/20z9ogaD3tWkeguRuz+/17cuS321PT3PAuyjQdg==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.5.tgz",
+			"integrity": "sha512-UmElV1OY2m/1KEEqTlIjieKfVwRg0Zwg4PLgNf0s3glAHXBN99KLpw5A5lrSYCa1Kp63czTpVll2MAqbZYIHoA==",
 			"cpu": [
 				"x64"
 			],
@@ -600,9 +600,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.3.tgz",
-			"integrity": "sha512-cO6hKV+99D1V7uNJQn1chWaF9EGp7qV2N8sGH99q9Y62bsbN6Il55EwJppEWT+JiqDRg396vWCgwdHwje8itBQ==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.5.tgz",
+			"integrity": "sha512-Q0LcU61v92tQB6ae+udZvOyZ0wfpGojtAKrrpAaIqmJ7+psq4cMIhT/9lfV6UQIpeItnq/2QDROhNLo00lOD1g==",
 			"cpu": [
 				"arm"
 			],
@@ -612,9 +612,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.3.tgz",
-			"integrity": "sha512-xANyq6lVg6KMO8UUs0LjA4q7di3tPpDbzLPgVEU2/F1ngIZ54eli8Zdt3uUUTMXVbgTCafIO+JPeGMhu097i3w==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.5.tgz",
+			"integrity": "sha512-dkRscpM+RrR2Ee3eOQmRWFjmV/payHEOrjyq1VZegRUa5OrZJ2MAxBNs05bZuY0YCtpqETDy1Ix4i/hRqX98cA==",
 			"cpu": [
 				"arm64"
 			],
@@ -624,9 +624,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.3.tgz",
-			"integrity": "sha512-TZJUfRTugVFATQToCMD8DNV6jv/KpSwhE1lLq5kXiQbBX3Pqw6dRKtzNkh5wcp0n09reBBq/7CGDERRw9KmE+g==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.5.tgz",
+			"integrity": "sha512-QaKFVOzzST2xzY4MAmiDmURagWLFh+zZtttuEnuNn19AiZ0T3fhPyjPPGwLNdiDT82ZE91hnfJsUiDwF9DClIQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -636,9 +636,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.3.tgz",
-			"integrity": "sha512-4/QVaRyaB5tkEAGfjVvWrmWdPF6F2NoaoO5uEP7N0AyeBw7l8SeCWWKAGrbx/00PUdHrJVURJiYikazslSKttQ==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.5.tgz",
+			"integrity": "sha512-HeGqmRJuyVg6/X6MpE2ur7GbymBPS8Np0S/vQFHDmocfORT+Zt76qu+69NUoxXzGqVP1pzaY6QIi0FJWLC3OPA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -648,9 +648,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.3.tgz",
-			"integrity": "sha512-koLC6D3pj1YLZSkTy/jsk3HOadp7q2h6VQl/lPX854twOmmLNekHB6yuS+MkWcKdGGdW1JPuPBv/ZYhr5Yhtdg==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
+			"integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
 			"cpu": [
 				"x64"
 			],
@@ -660,9 +660,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.3.tgz",
-			"integrity": "sha512-0OAkQ4HBp+JO2ip2Lgt/ShlrveOMzyhwt2D0KvqH28jFPqfZco28KSq76zymZwmU+F6GRojdxtQMJiNSXKNzeA==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.5.tgz",
+			"integrity": "sha512-ezyFUOwldYpj7AbkwyW9AJ203peub81CaAIVvckdkyH8EvhEIoKzaMFJj0G4qYJ5sw3BpqhFrsCc30t54HV8vg==",
 			"cpu": [
 				"x64"
 			],
@@ -672,9 +672,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.3.tgz",
-			"integrity": "sha512-z5uvoMvdRWggigOnsb9OOCLERHV0ykRZoRB5O+URPZC9zM3pkoMg5fN4NKu2oHqgkzZtfx9u4njqqlYEzM1v9A==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.5.tgz",
+			"integrity": "sha512-aHSsMnUw+0UETB0Hlv7B/ZHOGY5bQdwMKJSzGfDfvyhnpmVxLMGnQPGNE9wgqkLUs3+gbG1Qx02S2LLfJ5GaRQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -684,9 +684,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.3.tgz",
-			"integrity": "sha512-wxomCHjBVKws+O4N1WLnniKCXu7vkLtdq9Fl9CN/EbwEldojvUrkoHE/fBLZzC7IT/x12Ut6d6cRs4dFvqJkMg==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.5.tgz",
+			"integrity": "sha512-AiqiLkb9KSf7Lj/o1U3SEP9Zn+5NuVKgFdRIZkvd4N0+bYrTOovVd0+LmYCPQGbocT4kvFyK+LXCDiXPBF3fyA==",
 			"cpu": [
 				"ia32"
 			],
@@ -696,9 +696,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.3.tgz",
-			"integrity": "sha512-1Qf/qk/iEtx0aOi+AQQt5PBoW0mFngsm7bPuxHClC/hWh2hHBktR6ktSfUg5b5rC9v8hTwNmHE7lBWXkgqluUQ==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.5.tgz",
+			"integrity": "sha512-1q+mykKE3Vot1kaFJIDoUFv5TuW+QQVaf2FmTT9krg86pQrGStOSJJ0Zil7CFagyxDuouTepzt5Y5TVzyajOdQ==",
 			"cpu": [
 				"x64"
 			],
@@ -922,9 +922,9 @@
 			"dev": true
 		},
 		"node_modules/@vitejs/plugin-vue": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.2.tgz",
-			"integrity": "sha512-kEjJHrLb5ePBvjD0SPZwJlw1QTRcjjCA9sB5VyfonoXVBxTS7TMnqL6EkLt1Eu61RDeiuZ/WN9Hf6PxXhPI2uA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.3.tgz",
+			"integrity": "sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==",
 			"dev": true,
 			"engines": {
 				"node": "^18.0.0 || >=20.0.0"
@@ -935,49 +935,49 @@
 			}
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.5.tgz",
-			"integrity": "sha512-Daka7P1z2AgKjzuueWXhwzIsKu0NkLB6vGbNVEV2iJ8GJTrzraZo/Sk4GWCMRtd/qVi3zwnk+Owbd/xSZbwHtQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.15.tgz",
+			"integrity": "sha512-XcJQVOaxTKCnth1vCxEChteGuwG6wqnUHxAm1DO3gCz0+uXKaJNx8/digSz4dLALCy8n2lKq24jSUs8segoqIw==",
 			"dependencies": {
 				"@babel/parser": "^7.23.6",
-				"@vue/shared": "3.4.5",
+				"@vue/shared": "3.4.15",
 				"entities": "^4.5.0",
 				"estree-walker": "^2.0.2",
 				"source-map-js": "^1.0.2"
 			}
 		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.5.tgz",
-			"integrity": "sha512-J8YlxknJVd90SXFJ4HwGANSAXsx5I0lK30sO/zvYV7s5gXf7gZR7r/1BmZ2ju7RGH1lnc6bpBc6nL61yW+PsAQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.15.tgz",
+			"integrity": "sha512-wox0aasVV74zoXyblarOM3AZQz/Z+OunYcIHe1OsGclCHt8RsRm04DObjefaI82u6XDzv+qGWZ24tIsRAIi5MQ==",
 			"dependencies": {
-				"@vue/compiler-core": "3.4.5",
-				"@vue/shared": "3.4.5"
+				"@vue/compiler-core": "3.4.15",
+				"@vue/shared": "3.4.15"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.5.tgz",
-			"integrity": "sha512-jauvkDuSSUbP0ebhfNqljhShA90YEfX/0wZ+w40oZF43IjGyWYjqYaJbvMJwGOd+9+vODW6eSvnk28f0SGV7OQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.15.tgz",
+			"integrity": "sha512-LCn5M6QpkpFsh3GQvs2mJUOAlBQcCco8D60Bcqmf3O3w5a+KWS5GvYbrrJBkgvL1BDnTp+e8q0lXCLgHhKguBA==",
 			"dependencies": {
 				"@babel/parser": "^7.23.6",
-				"@vue/compiler-core": "3.4.5",
-				"@vue/compiler-dom": "3.4.5",
-				"@vue/compiler-ssr": "3.4.5",
-				"@vue/shared": "3.4.5",
+				"@vue/compiler-core": "3.4.15",
+				"@vue/compiler-dom": "3.4.15",
+				"@vue/compiler-ssr": "3.4.15",
+				"@vue/shared": "3.4.15",
 				"estree-walker": "^2.0.2",
 				"magic-string": "^0.30.5",
-				"postcss": "^8.4.32",
+				"postcss": "^8.4.33",
 				"source-map-js": "^1.0.2"
 			}
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.5.tgz",
-			"integrity": "sha512-DDdEcDzj2lWTMfUMMtEpLDhURai9LhM0zSZ219jCt7b2Vyl0/jy3keFgCPMitG0V1S1YG4Cmws3lWHWdxHQOpg==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.15.tgz",
+			"integrity": "sha512-1jdeQyiGznr8gjFDadVmOJqZiLNSsMa5ZgqavkPZ8O2wjHv0tVuAEsw5hTdUoUW4232vpBbL/wJhzVW/JwY1Uw==",
 			"dependencies": {
-				"@vue/compiler-dom": "3.4.5",
-				"@vue/shared": "3.4.5"
+				"@vue/compiler-dom": "3.4.15",
+				"@vue/shared": "3.4.15"
 			}
 		},
 		"node_modules/@vue/devtools-api": {
@@ -986,48 +986,48 @@
 			"integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
 		},
 		"node_modules/@vue/reactivity": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.5.tgz",
-			"integrity": "sha512-BcWkKvjdvqJwb7BhhFkXPLDCecX4d4a6GATvCduJQDLv21PkPowAE5GKuIE5p6RC07/Lp9FMkkq4AYCTVF5KlQ==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.15.tgz",
+			"integrity": "sha512-55yJh2bsff20K5O84MxSvXKPHHt17I2EomHznvFiJCAZpJTNW8IuLj1xZWMLELRhBK3kkFV/1ErZGHJfah7i7w==",
 			"dependencies": {
-				"@vue/shared": "3.4.5"
+				"@vue/shared": "3.4.15"
 			}
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.5.tgz",
-			"integrity": "sha512-wh9ELIOQKeWT9SaUPdLrsxRkZv14jp+SJm9aiQGWio+/MWNM3Lib0wE6CoKEqQ9+SCYyGjDBhTOTtO47kCgbkg==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.15.tgz",
+			"integrity": "sha512-6E3by5m6v1AkW0McCeAyhHTw+3y17YCOKG0U0HDKDscV4Hs0kgNT5G+GCHak16jKgcCDHpI9xe5NKb8sdLCLdw==",
 			"dependencies": {
-				"@vue/reactivity": "3.4.5",
-				"@vue/shared": "3.4.5"
+				"@vue/reactivity": "3.4.15",
+				"@vue/shared": "3.4.15"
 			}
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.5.tgz",
-			"integrity": "sha512-n5ewvOjyG3IEpqGBahdPXODFSpVlSz3H4LF76Sx0XAqpIOqyJ5bIb2PrdYuH2ogBMAQPh+o5tnoH4nJpBr8U0Q==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.15.tgz",
+			"integrity": "sha512-EVW8D6vfFVq3V/yDKNPBFkZKGMFSvZrUQmx196o/v2tHKdwWdiZjYUBS+0Ez3+ohRyF8Njwy/6FH5gYJ75liUw==",
 			"dependencies": {
-				"@vue/runtime-core": "3.4.5",
-				"@vue/shared": "3.4.5",
+				"@vue/runtime-core": "3.4.15",
+				"@vue/shared": "3.4.15",
 				"csstype": "^3.1.3"
 			}
 		},
 		"node_modules/@vue/server-renderer": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.5.tgz",
-			"integrity": "sha512-jOFc/VE87yvifQpNju12VcqimH8pBLxdcT+t3xMeiED1K6DfH9SORyhFEoZlW5TG2Vwfn3Ul5KE+1aC99xnSBg==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.15.tgz",
+			"integrity": "sha512-3HYzaidu9cHjrT+qGUuDhFYvF/j643bHC6uUN9BgM11DVy+pM6ATsG6uPBLnkwOgs7BpJABReLmpL3ZPAsUaqw==",
 			"dependencies": {
-				"@vue/compiler-ssr": "3.4.5",
-				"@vue/shared": "3.4.5"
+				"@vue/compiler-ssr": "3.4.15",
+				"@vue/shared": "3.4.15"
 			},
 			"peerDependencies": {
-				"vue": "3.4.5"
+				"vue": "3.4.15"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.5.tgz",
-			"integrity": "sha512-6XptuzlMvN4l4cDnDw36pdGEV+9njYkQ1ZE0Q6iZLwrKefKaOJyiFmcP3/KBDHbt72cJZGtllAc1GaHe6XGAyg=="
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.15.tgz",
+			"integrity": "sha512-KzfPTxVaWfB+eGcGdbSf4CWdaXcGDqckoeXUh7SB3fZdEtzPCK2Vq9B/lRRL3yutax/LWITz+SwvgyOxz5V75g=="
 		},
 		"node_modules/@vuetify/loader-shared": {
 			"version": "2.0.1",
@@ -1396,9 +1396,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-vue": {
-			"version": "9.20.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.20.0.tgz",
-			"integrity": "sha512-9/DV5CM7ItfgWmXjL6j3zyDtVTrslYdnEm+rnYNajdElx17b3erxi/Wc6FY7t3BQ6dgo0t/UBpgiWCOKtJyN8Q==",
+			"version": "9.20.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.20.1.tgz",
+			"integrity": "sha512-GyCs8K3lkEvoyC1VV97GJhP1SvqsKCiWGHnbn0gVUYiUhaH2+nB+Dv1uekv1THFMPbBfYxukrzQdltw950k+LQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
@@ -2239,9 +2239,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.3.tgz",
-			"integrity": "sha512-JnchF0ZGFiqGpAPjg3e89j656Ne4tTtCY1VZc1AxtoQcRIxjTu9jyYHBAtkDXE+X681n4un/nX9SU52AroSRzg==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.5.tgz",
+			"integrity": "sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==",
 			"devOptional": true,
 			"dependencies": {
 				"@types/estree": "1.0.5"
@@ -2254,19 +2254,19 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.9.3",
-				"@rollup/rollup-android-arm64": "4.9.3",
-				"@rollup/rollup-darwin-arm64": "4.9.3",
-				"@rollup/rollup-darwin-x64": "4.9.3",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.9.3",
-				"@rollup/rollup-linux-arm64-gnu": "4.9.3",
-				"@rollup/rollup-linux-arm64-musl": "4.9.3",
-				"@rollup/rollup-linux-riscv64-gnu": "4.9.3",
-				"@rollup/rollup-linux-x64-gnu": "4.9.3",
-				"@rollup/rollup-linux-x64-musl": "4.9.3",
-				"@rollup/rollup-win32-arm64-msvc": "4.9.3",
-				"@rollup/rollup-win32-ia32-msvc": "4.9.3",
-				"@rollup/rollup-win32-x64-msvc": "4.9.3",
+				"@rollup/rollup-android-arm-eabi": "4.9.5",
+				"@rollup/rollup-android-arm64": "4.9.5",
+				"@rollup/rollup-darwin-arm64": "4.9.5",
+				"@rollup/rollup-darwin-x64": "4.9.5",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.9.5",
+				"@rollup/rollup-linux-arm64-gnu": "4.9.5",
+				"@rollup/rollup-linux-arm64-musl": "4.9.5",
+				"@rollup/rollup-linux-riscv64-gnu": "4.9.5",
+				"@rollup/rollup-linux-x64-gnu": "4.9.5",
+				"@rollup/rollup-linux-x64-musl": "4.9.5",
+				"@rollup/rollup-win32-arm64-msvc": "4.9.5",
+				"@rollup/rollup-win32-ia32-msvc": "4.9.5",
+				"@rollup/rollup-win32-x64-msvc": "4.9.5",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -2540,15 +2540,15 @@
 			}
 		},
 		"node_modules/vue": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.4.5.tgz",
-			"integrity": "sha512-VH6nHFhLPjgu2oh5vEBXoNZxsGHuZNr3qf4PHClwJWw6IDqw6B3x+4J+ABdoZ0aJuT8Zi0zf3GpGlLQCrGWHrw==",
+			"version": "3.4.15",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.4.15.tgz",
+			"integrity": "sha512-jC0GH4KkWLWJOEQjOpkqU1bQsBwf4R1rsFtw5GQJbjHVKWDzO6P0nWWBTmjp1xSemAioDFj1jdaK1qa3DnMQoQ==",
 			"dependencies": {
-				"@vue/compiler-dom": "3.4.5",
-				"@vue/compiler-sfc": "3.4.5",
-				"@vue/runtime-dom": "3.4.5",
-				"@vue/server-renderer": "3.4.5",
-				"@vue/shared": "3.4.5"
+				"@vue/compiler-dom": "3.4.15",
+				"@vue/compiler-sfc": "3.4.15",
+				"@vue/runtime-dom": "3.4.15",
+				"@vue/server-renderer": "3.4.15",
+				"@vue/shared": "3.4.15"
 			},
 			"peerDependencies": {
 				"typescript": "*"
@@ -2598,9 +2598,9 @@
 			}
 		},
 		"node_modules/vuetify": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.4.9.tgz",
-			"integrity": "sha512-pgBPdbgrHHHZWRybWevzRFezMax6CP2MccTivjOZSOF0XsnzoNOJGGpkTgIfBrk4UCp9jKx6JOJIztGtx/IcSw==",
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.4.11.tgz",
+			"integrity": "sha512-8kF1G6/VHZvZEuwL91DybWRimM0d1ueupTfFcxrtLDNMmytCI0PF/hf/Z7tCPe1gfMXrENk9FOP6ojydSmNFpQ==",
 			"engines": {
 				"node": "^12.20 || >=14.13"
 			},

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"eslint": "^8.56.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-prettier-vue": "^5.0.0",
-		"eslint-plugin-vue": "^9.19.2",
+		"eslint-plugin-vue": "^9.20.0",
 		"prettier": "3.1.1",
 		"vite": "^5.0.11",
 		"vite-plugin-vuetify": "^2.0.1"

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-app :theme="theme">
+	<v-app :theme>
 		<v-layout class="rounded rounded-md">
 			<AppSidebar />
 			<router-view />

--- a/ui/src/components/AppHeader.vue
+++ b/ui/src/components/AppHeader.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-app-bar :title="title" density="comfortable">
+	<v-app-bar :title density="comfortable">
 		<template #prepend>
 			<v-btn
 				:icon="mdiArrowLeft"
@@ -19,8 +19,8 @@
 		<v-progress-linear
 			v-model="progress"
 			:active="loading"
-			:indeterminate="indeterminate"
-			:stream="stream"
+			:indeterminate
+			:stream
 			absolute
 			location="bottom"
 		/>

--- a/ui/src/components/CopyButton.vue
+++ b/ui/src/components/CopyButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<TextCopier v-slot="{ props: copierProps, copy }" :text="text">
+	<TextCopier v-slot="{ props: copierProps, copy }" :text>
 		<v-slide-x-reverse-transition>
 			<v-btn
 				v-if="text && !hidden"

--- a/ui/src/components/IconButton.vue
+++ b/ui/src/components/IconButton.vue
@@ -1,6 +1,6 @@
 <template>
 	<SimpleTooltip v-slot="{ props: tooltipProps }" :text="tooltip">
-		<v-btn v-bind="{ ...tooltipProps, ...$attrs }" :icon="icon" />
+		<v-btn v-bind="{ ...tooltipProps, ...$attrs }" :icon />
 	</SimpleTooltip>
 </template>
 

--- a/ui/src/components/SimpleTooltip.vue
+++ b/ui/src/components/SimpleTooltip.vue
@@ -1,7 +1,7 @@
 <template>
-	<v-tooltip :text="text" :open-delay="openDelay">
+	<v-tooltip :text :open-delay="openDelay">
 		<template #activator="{ props }">
-			<slot :props="props" />
+			<slot :props />
 		</template>
 	</v-tooltip>
 </template>

--- a/ui/src/components/TextCopier.vue
+++ b/ui/src/components/TextCopier.vue
@@ -1,5 +1,5 @@
 <template>
-	<slot v-if="!tooltip" :copy="copy" :copied="copied" :reset="reset" />
+	<slot v-if="!tooltip" :copy :copied :reset />
 
 	<SimpleTooltip
 		v-else
@@ -7,7 +7,7 @@
 		v-model="showTooltip"
 		:text="copied ? 'Copied!' : 'Copy'"
 	>
-		<slot :copy="copy" :copied="copied" :reset="reset" :props="tooltipProps" />
+		<slot :copy :copied :reset :props="tooltipProps" />
 	</SimpleTooltip>
 </template>
 

--- a/ui/src/components/mods/ModDetailsDialog.vue
+++ b/ui/src/components/mods/ModDetailsDialog.vue
@@ -54,7 +54,7 @@
 			<v-card-text>
 				<p class="text-body-1 mt-2 mb-6">{{ mod.description }}</p>
 
-				<ModTags :mod="mod" class="mb-6" />
+				<ModTags :mod class="mb-6" />
 
 				<h2 class="text-h5 mb-2">Authors</h2>
 				<ModAuthors :authors="mod.authors" class="mb-6" />
@@ -71,7 +71,7 @@
 						tooltip="Release page"
 					/>
 				</h2>
-				<ModVersionInfoPanels :version="version" />
+				<ModVersionInfoPanels :version />
 			</v-card-text>
 
 			<!-- Mod actions -->
@@ -81,7 +81,7 @@
 				<ModUninstaller
 					v-if="mod.installedVersion"
 					v-slot="{ uninstall, uninstalling, busy }"
-					:mod="mod"
+					:mod
 				>
 					<v-btn
 						:prepend-icon="mdiDelete"
@@ -96,7 +96,7 @@
 				<ModUpdater
 					v-if="updateAvailable"
 					v-slot="{ update, updating, busy }"
-					:mod="mod"
+					:mod
 					:version="semver"
 				>
 					<v-btn
@@ -112,7 +112,7 @@
 				<ModInstaller
 					v-else-if="!version.isUnrecognized"
 					v-slot="{ install, installing, busy }"
-					:mod="mod"
+					:mod
 					:version="semver"
 				>
 					<v-btn

--- a/ui/src/components/mods/ModInstaller.vue
+++ b/ui/src/components/mods/ModInstaller.vue
@@ -1,11 +1,5 @@
 <template>
-	<slot
-		:install="install"
-		:busy="busy"
-		:installing="installing"
-		:installed="installed"
-		:error="error"
-	/>
+	<slot :install :busy :installing :installed :error />
 </template>
 
 <script setup>

--- a/ui/src/components/mods/ModTable.vue
+++ b/ui/src/components/mods/ModTable.vue
@@ -1,11 +1,11 @@
 <template>
 	<v-data-table
 		ref="dataTable"
-		:headers="headers"
-		:items="items"
+		:headers
+		:items
 		item-key="id"
 		:items-per-page="settings.current[modsPerPageSetting]"
-		:loading="loading"
+		:loading
 		:search="filter"
 		filter-mode="some"
 		:group-by="groupBy"
@@ -29,13 +29,13 @@
 				<!-- eslint-enable vue/no-v-html -->
 				<td>{{ mod.description }}</td>
 				<td v-if="!groupBy">{{ mod.category }}</td>
-				<td style="width: 7em"><ModVersionStatus :mod="mod" /></td>
+				<td style="width: 7em"><ModVersionStatus :mod /></td>
 				<td>
 					<div class="d-flex flex-nowrap justify-end">
 						<ModUninstaller
 							v-if="mod.installedVersion"
 							v-slot="{ uninstall, uninstalling, busy }"
-							:mod="mod"
+							:mod
 						>
 							<IconButton
 								:icon="mdiDelete"
@@ -51,7 +51,7 @@
 						<ModInstaller
 							v-if="!mod.hasUpdate && !mod.isUnrecognized"
 							v-slot="{ install, installing, busy }"
-							:mod="mod"
+							:mod
 						>
 							<IconButton
 								:icon="mod.installedVersion ? mdiRefresh : mdiDownload"
@@ -67,7 +67,7 @@
 						<ModUpdater
 							v-else-if="mod.hasUpdate"
 							v-slot="{ update, updating, busy }"
-							:mod="mod"
+							:mod
 						>
 							<IconButton
 								:icon="mdiUpdate"

--- a/ui/src/components/mods/ModUninstaller.vue
+++ b/ui/src/components/mods/ModUninstaller.vue
@@ -1,11 +1,5 @@
 <template>
-	<slot
-		:uninstall="uninstall"
-		:busy="busy"
-		:uninstalling="uninstalling"
-		:uninstalled="uninstalled"
-		:error="error"
-	/>
+	<slot :uninstall :busy :uninstalling :uninstalled :error />
 </template>
 
 <script setup>

--- a/ui/src/components/mods/ModUpdater.vue
+++ b/ui/src/components/mods/ModUpdater.vue
@@ -1,11 +1,5 @@
 <template>
-	<slot
-		:update="update"
-		:busy="busy"
-		:updating="updating"
-		:updated="updated"
-		:error="error"
-	/>
+	<slot :update :busy :updating :updated :error />
 </template>
 
 <script setup>

--- a/ui/src/components/pages/InstalledModsPage.vue
+++ b/ui/src/components/pages/InstalledModsPage.vue
@@ -2,7 +2,7 @@
 	<ModsPage
 		title="Installed Mods"
 		no-data-text="No mods have been installed yet."
-		:mods="mods"
+		:mods
 		:load-mods="loadMods"
 		:grouped="false"
 	>

--- a/ui/src/components/pages/ModsPage.vue
+++ b/ui/src/components/pages/ModsPage.vue
@@ -1,5 +1,5 @@
 <template>
-	<AppHeader :title="title">
+	<AppHeader :title>
 		<template #actions>
 			<slot name="actions" :resonite-path-exists="resonitePathExists" />
 
@@ -12,7 +12,7 @@
 
 			<IconButton
 				:icon="mdiRefresh"
-				:loading="loading"
+				:loading
 				tooltip="Refresh mods"
 				@click="loadModsFromFn(true)"
 			/>
@@ -40,11 +40,11 @@
 
 		<ModTable
 			ref="modTable"
-			:mods="mods"
+			:mods
 			:disabled="disabled || !resonitePathExists"
-			:loading="loading"
+			:loading
 			:style="`height: ${tableHeight}`"
-			:grouped="grouped"
+			:grouped
 			:no-data-text="noDataText"
 			@show-mod-details="showModDetails"
 		/>

--- a/ui/src/components/pages/SessionLogPage.vue
+++ b/ui/src/components/pages/SessionLogPage.vue
@@ -1,5 +1,5 @@
 <template>
-	<AppHeader title="Console" :loading="loading" :indeterminate="loading">
+	<AppHeader title="Console" :loading :indeterminate="loading">
 		<template #actions>
 			<IconButton
 				:icon="mdiFolderText"

--- a/ui/src/components/settings/DropdownSetting.vue
+++ b/ui/src/components/settings/DropdownSetting.vue
@@ -1,9 +1,9 @@
 <template>
 	<v-select
 		v-model="settings.current[setting]"
-		:label="label"
-		:items="items"
-		:variant="variant"
+		:label
+		:items
+		:variant
 		item-title="label"
 		item-value="value"
 		@update:model-value="save"

--- a/ui/src/components/settings/NumberSetting.vue
+++ b/ui/src/components/settings/NumberSetting.vue
@@ -1,10 +1,10 @@
 <template>
 	<v-text-field
 		v-model="settings.current[setting]"
-		:label="label"
+		:label
 		:rules="effectiveRules"
-		:variant="variant"
-		:suffix="suffix"
+		:variant
+		:suffix
 		type="number"
 		@keypress.enter="save"
 		@blur="save"

--- a/ui/src/components/settings/ResonitePathSetting.vue
+++ b/ui/src/components/settings/ResonitePathSetting.vue
@@ -2,7 +2,7 @@
 	<v-text-field
 		v-model="settings.current.resonitePath"
 		label="Resonite path"
-		:variant="variant"
+		:variant
 		readonly
 	>
 		<template #append-inner>

--- a/ui/src/components/settings/SwitchSetting.vue
+++ b/ui/src/components/settings/SwitchSetting.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-switch
 		v-model="settings.current[setting]"
-		:label="label"
+		:label
 		color="primary"
 		hide-details
 		@update:model-value="save"

--- a/ui/src/components/settings/TextSetting.vue
+++ b/ui/src/components/settings/TextSetting.vue
@@ -1,9 +1,9 @@
 <template>
 	<v-text-field
 		v-model="settings.current[setting]"
-		:label="label"
-		:rules="rules"
-		:variant="variant"
+		:label
+		:rules
+		:variant
 		@keypress.enter="save"
 		@blur="save"
 	/>


### PR DESCRIPTION
This replaces all occurrences of `:something="something"` with `:something` in Vue templates, taking advantage of the new same-name shorthand syntax for v-binds introduced in Vue 3.4.