### PR TITLE
Use an extension trait to map Errors into ArtifactErrors

### DIFF
--- a/crates/resolute/src/manager/delete.rs
+++ b/crates/resolute/src/manager/delete.rs
@@ -6,7 +6,7 @@ use log::info;
 use crate::mods::{ModArtifact, ModVersion};
 use crate::{Error, Result};
 
-use super::artifacts::{self, ArtifactAction, ArtifactError, ArtifactErrorVec};
+use super::artifacts::{self, ArtifactAction, ArtifactError, ArtifactErrorVec, MappableToArtifactError};
 
 /// Handles deleting mods
 pub struct Deleter {
@@ -41,7 +41,7 @@ impl Deleter {
 	pub async fn delete_artifact(&self, artifact: &ModArtifact) -> core::result::Result<PathBuf, ArtifactError> {
 		let path = artifact
 			.dest_within(&self.base_dest)
-			.map_err(ArtifactError::map_pathless(ArtifactAction::Delete))?;
+			.map_pathless_artifact_err(ArtifactAction::Delete)?;
 		artifacts::delete(&path).await?;
 
 		info!("Deleted artifact file {}", path.display());

--- a/crates/resolute/src/manager/mod.rs
+++ b/crates/resolute/src/manager/mod.rs
@@ -206,9 +206,9 @@ impl_ModManager_with_without_db! {
 
 						for umod in unrecognized_matches {
 							debug!(
-									"Removing unrecognized mod {} from the database during installed mod marking, repacing with {}",
-									umod, rmod
-								);
+										"Removing unrecognized mod {} from the database during installed mod marking, repacing with {}",
+										umod, rmod
+									);
 							self.db.remove_mod_by_id(&umod.id)?;
 							removed_mods.insert(umod.id.clone(), umod.clone());
 						}
@@ -258,8 +258,7 @@ impl_ModManager_with_without_db! {
 			rmod: &ResoluteMod,
 			version: impl AsRef<str>,
 			progress: impl Fn(u64, u64),
-		) -> Result<()>
-		{
+		) -> Result<()> {
 			// Ensure the mod is actually installed and determine which version
 			let old_version = {
 				let version = match &rmod.installed_version {


### PR DESCRIPTION
Small refactor that replaces `ArtifactError::map_pathless` with a new `MappableToArtifactError` extension trait.