### PR TITLE
Ignore file not found errors when deleting artifacts

### DIFF
--- a/crates/resolute/src/manager/delete.rs
+++ b/crates/resolute/src/manager/delete.rs
@@ -42,7 +42,7 @@ impl Deleter {
 		let path = artifact
 			.dest_within(&self.base_dest)
 			.map_pathless_artifact_err(ArtifactAction::Delete)?;
-		artifacts::delete(&path).await?;
+		artifacts::delete(&path, true).await?;
 
 		info!("Deleted artifact file {}", path.display());
 		Ok(path)
@@ -70,7 +70,7 @@ impl Deleter {
 		// Delete each unnecessary artifact path and track any failures
 		let mut failed = ArtifactErrorVec::new();
 		for path in unnecessary_paths {
-			if let Err(err) = artifacts::delete(path).await {
+			if let Err(err) = artifacts::delete(path, true).await {
 				failed.push(err);
 			}
 			info!("Deleted left-over artifact file {}", path.display());

--- a/crates/resolute/src/manager/download.rs
+++ b/crates/resolute/src/manager/download.rs
@@ -272,7 +272,7 @@ impl<'a> DownloadedArtifact<'a> {
 
 	/// Cancels the artifact. Deletes the downloaded file from the temporary destination.
 	pub async fn cancel(self) -> Result<()> {
-		artifacts::delete(&self.tmp_dest).await?;
+		artifacts::delete(&self.tmp_dest, true).await?;
 		debug!("Deleted temporary artifact file {}", self.tmp_dest.display());
 		Ok(())
 	}
@@ -299,7 +299,7 @@ impl FinalizedArtifact<'_> {
 	/// Deletes the downloaded artifact and renames the old artifact back to its original final destination.
 	pub async fn undo(self) -> Result<()> {
 		// Delete the artifact from its final destination
-		artifacts::delete(&self.final_dest).await?;
+		artifacts::delete(&self.final_dest, true).await?;
 		debug!("Deleted artifact file {}", self.final_dest.display());
 
 		// Rename the old artifact back to the final name if there was one
@@ -319,7 +319,7 @@ impl FinalizedArtifact<'_> {
 	/// Fails if there was no old artifact or if there is an issue during its deletion.
 	pub async fn delete_old(self) -> Result<()> {
 		let old_dest = self.old_dest.ok_or_else(|| Error::NoOldArtifact)?;
-		artifacts::delete(&old_dest).await?;
+		artifacts::delete(&old_dest, true).await?;
 		debug!("Deleted old artifact file {}", old_dest.display());
 		Ok(())
 	}


### PR DESCRIPTION
Ignores file not found errors when artifacts are being deleted, allowing successful uninstallation of mods that have already had their artifact(s) deleted.