### PR TITLE
Switch Cargo license properties to allow newer than (L)GPL3

### DIFF
--- a/crates/resolute/Cargo.toml
+++ b/crates/resolute/Cargo.toml
@@ -3,7 +3,7 @@ name = "resolute"
 version = "0.6.0"
 description = "Resonite mod manager, manifest, and dependency resolution library"
 authors = ["Schuyler Cebulskie <me@gawdl3y.dev>"]
-license = "LGPL-3.0"
+license = "LGPL-3.0-or-later"
 repository = "https://github.com/Gawdl3y/Resolute"
 edition = "2021"
 

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -3,7 +3,7 @@ name = "resolute-app"
 version = "0.7.1"
 description = "Resolute, a mod manager for Resonite"
 authors = ["Schuyler Cebulskie <me@gawdl3y.dev>"]
-license = "GPL-3.0"
+license = "GPL-3.0-or-later"
 repository = "https://github.com/Gawdl3y/Resolute"
 edition = "2021"
 


### PR DESCRIPTION
Replaces the deprecated `GPL-3.0` and `LGPL-3.0` license IDs with `GPL-3.0-or-later` and `LGPL-3.0-or-later`, respectively.