### PR TITLE
Fix init error window with single-line error messages

### DIFF
--- a/ui/src/ErrorApp.vue
+++ b/ui/src/ErrorApp.vue
@@ -57,7 +57,10 @@ const themeMediaMatcher = window.matchMedia('(prefers-color-scheme: dark)');
 const systemTheme = ref(themeMediaMatcher.matches ? 'dark' : 'light');
 
 const error = globalThis.error;
-const errorRows = Math.min(Math.max(error.match(/\n/g).length + 2, 5), 10);
+const errorRows = Math.min(
+	Math.max((error.match(/\n/g)?.length ?? 0) + 2, 5),
+	10,
+);
 
 onMounted(() => {
 	info('ErrorApp mounted - showing error window');


### PR DESCRIPTION
Fixes the initialization error window not being displayed when the error message only contains a single line of text.