### PR TITLE
Add strict-ish CSP to Tauri config

### DIFF
--- a/crates/tauri-app/tauri.conf.json
+++ b/crates/tauri-app/tauri.conf.json
@@ -10,7 +10,7 @@
 	},
 	"app": {
 		"security": {
-			"csp": null
+			"csp": "default-src 'self'; connect-src 'self' ipc.localhost; style-src 'self' 'nonce-cEStTGt8qsTHCwfCKZ5ecUbba33gWfrY'; img-src *"
 		},
 		"windows": [
 			{

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -49,6 +49,9 @@ app
 						aliases,
 						sets: { mdi },
 					},
+					theme: {
+						cspNonce: 'cEStTGt8qsTHCwfCKZ5ecUbba33gWfrY',
+					},
 				}),
 			)
 			.mount('#app');


### PR DESCRIPTION
Adds a CSP to the Tauri config and a nonce to the Vuetify config for its injected styles.