### PR TITLE
Add menu to open various folders to the installed mods page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,6 +3737,7 @@ dependencies = [
  "native_db",
  "once_cell",
  "opener",
+ "path-clean",
  "reqwest",
  "resolute",
  "serde",

--- a/crates/resolute/src/mods.rs
+++ b/crates/resolute/src/mods.rs
@@ -359,7 +359,7 @@ impl ModArtifact {
 		let mut dest = base_path.join(match &self.install_location {
 			Some(install_location) => {
 				let path = Path::new(install_location);
-				path.strip_prefix("/").or::<Error>(Ok(path))?
+				path.strip_prefix("/").unwrap_or(path)
 			}
 			None => Path::new("rml_mods"),
 		});

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -23,6 +23,7 @@ sha2 = "0.10"
 native_db = "0.5"
 once_cell = "1.19"
 itertools = "0.12"
+path-clean = "1.0"
 opener = "0.6"
 reqwest = { version = "0.11", features = [
 	"rustls-tls",

--- a/crates/tauri-app/src/commands/system.rs
+++ b/crates/tauri-app/src/commands/system.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use itertools::Itertools;
 use log::{error, info};

--- a/crates/tauri-app/src/commands/system.rs
+++ b/crates/tauri-app/src/commands/system.rs
@@ -1,9 +1,12 @@
+use std::path::{Path, PathBuf};
+
 use itertools::Itertools;
 use log::{error, info};
+use path_clean::PathClean;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager, Window};
-use tokio::io::AsyncReadExt;
+use tokio::{fs, io::AsyncReadExt};
 
 use crate::settings;
 
@@ -109,6 +112,39 @@ pub(crate) async fn get_session_log(app: AppHandle) -> Result<String, String> {
 	};
 
 	Ok(log)
+}
+
+/// Opens the Resonite directory or a child of the Resonite directory in the system file browser, ensuring that child
+/// directories actually exist first.
+#[tauri::command]
+pub(crate) async fn open_resonite_dir(app: AppHandle, child: Option<PathBuf>) -> Result<(), String> {
+	let resonite_path =
+		PathBuf::from(settings::require::<String>(&app, "resonitePath").map_err(|err| err.to_string())?);
+
+	// Determine the full path to open
+	let path = match child {
+		Some(child) => {
+			let path = resonite_path.join(child.strip_prefix("/").unwrap_or(&child));
+
+			// Ensure the path didn't traverse above the Resonite path
+			let path = path.clean();
+			if !path.starts_with(resonite_path) {
+				return Err(format!(
+					"Given path ({}) is not a child of the Resonite directory",
+					child.display()
+				));
+			}
+
+			path
+		}
+		None => resonite_path,
+	};
+
+	// Ensure the directory exists, then open it
+	fs::create_dir_all(&path).await.map_err(|err| format!("Unable to ensure existence of Resonite directory: {}", err))?;
+	opener::open(path).map_err(|err| format!("Unable to open Resonite directory: {}", err))?;
+
+	Ok(())
 }
 
 /// Opens the app's log directory in the system file browser

--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -84,6 +84,7 @@ fn main() -> anyhow::Result<()> {
 			commands::system::verify_resonite_path,
 			commands::system::hash_file,
 			commands::system::get_session_log,
+			commands::system::open_resonite_dir,
 			commands::system::open_log_dir,
 			commands::settings::resonite_path_changed,
 			commands::settings::connect_timeout_changed,

--- a/ui/src/components/pages/InstalledModsPage.vue
+++ b/ui/src/components/pages/InstalledModsPage.vue
@@ -7,6 +7,35 @@
 		:grouped="false"
 	>
 		<template #actions="{ resonitePathExists }">
+			<v-menu>
+				<template #activator="{ props: menuProps }">
+					<IconButton
+						:icon="mdiFolder"
+						:disabled="!resonitePathExists"
+						tooltip="Open folder"
+						v-bind="menuProps"
+					/>
+				</template>
+
+				<v-list density="comfortable">
+					<v-list-item title="RML Mods" @click="openResoniteDir('rml_mods')" />
+					<v-list-item
+						title="RML Libraries"
+						@click="openResoniteDir('rml_libs')"
+					/>
+					<v-list-item
+						title="RML Config"
+						@click="openResoniteDir('rml_config')"
+					/>
+					<v-list-item title="Resonite" @click="openResoniteDir()" />
+					<v-list-item title="Resonite Logs" @click="openResoniteDir('Logs')" />
+					<v-list-item
+						title="Resonite Libraries"
+						@click="openResoniteDir('Libraries')"
+					/>
+				</v-list>
+			</v-menu>
+
 			<IconButton
 				:icon="mdiToyBrickSearch"
 				:loading="modStore.discovering"
@@ -28,9 +57,10 @@
 
 <script setup>
 import { computed } from 'vue';
+import { invoke } from '@tauri-apps/api/core';
 import { ask } from '@tauri-apps/plugin-dialog';
 import { info, error } from '@tauri-apps/plugin-log';
-import { mdiToyBrickSearch, mdiUpdate } from '@mdi/js';
+import { mdiFolder, mdiToyBrickSearch, mdiUpdate } from '@mdi/js';
 
 import useNotifications from '../../composables/notifications';
 import useModStore from '../../stores/mods';
@@ -167,5 +197,13 @@ async function discoverInstalledMods() {
 			{ alert: true },
 		);
 	}
+}
+
+/**
+ * Ensures the existence of and opens a Resonite directory or child directory in the default file browser
+ * @param {String} [child] Child directory to open
+ */
+async function openResoniteDir(child = null) {
+	await invoke('open_resonite_dir', { child });
 }
 </script>


### PR DESCRIPTION
Adds a button to the toolbar on the installed mods page that presents a menu to open various folders in the system file browser.

Closes #37