### PR TITLE
Strip debug info in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ resolver = "2"
 lto = "thin"
 codegen-units = 1
 panic = "abort"
+strip = "debuginfo"


### PR DESCRIPTION
This is going to be the default in Cargo 1.77.