### PR TITLE
Use Rust 1.76 in workflows

### DIFF
--- a/.github/workflows/build-tauri-app.yml
+++ b/.github/workflows/build-tauri-app.yml
@@ -62,8 +62,8 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust 1.76
+        uses: dtolnay/rust-toolchain@1.76
 
       - name: Install system dependencies (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust 1.76
+        uses: dtolnay/rust-toolchain@1.76
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
The rust-toolchain action has not yet updated their stable tag to 1.76.