### PR TITLE
Add logging of OS and architecture

### DIFF
--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -144,10 +144,10 @@ async fn init(app: &AppHandle) -> Result<(), anyhow::Error> {
 	);
 
 	#[cfg(debug_assertions)]
-	{
-		warn!("App is in debug mode");
-		debug!("Tauri version: {}", tauri::VERSION);
-	}
+	warn!("App is in debug mode");
+
+	debug!("Operating system: {} {}", env::consts::OS, env::consts::ARCH);
+	debug!("Tauri version: {}", tauri::VERSION);
 
 	// Ensure all needed app directories are created
 	if let Err(err) = create_app_dirs(app).await {


### PR DESCRIPTION
- Logs the current OS and architecture on app startup
- Makes the Tauri version always logged instead of only for debug builds