### PR TITLE
Don't run mod autodiscovery if the Resonite path isn't configured

### DIFF
--- a/ui/src/components/SetupGuideDialog.vue
+++ b/ui/src/components/SetupGuideDialog.vue
@@ -227,7 +227,11 @@ function advanceStep() {
 		}, 500);
 
 		// Kick off mod autodiscovery
-		if (!settings.current.modsAutodiscovered2 && !modStore.discovering) {
+		const shouldAutodiscover =
+			!settings.current.modsAutodiscovered2 &&
+			settings.current.resonitePath &&
+			!modStore.discovering;
+		if (shouldAutodiscover) {
 			modStore
 				.discover()
 				.then(() => {

--- a/ui/src/components/pages/ModsPage.vue
+++ b/ui/src/components/pages/ModsPage.vue
@@ -112,6 +112,7 @@ onMounted(() => {
 	// Automatically discover mods if it hasn't been done before and the setup guide has already been done
 	const shouldAutodiscover =
 		!settings.current.modsAutodiscovered2 &&
+		settings.current.resonitePath &&
 		settings.current.setupGuideDone &&
 		!modStore.discovering;
 	if (shouldAutodiscover) {


### PR DESCRIPTION
Fixes frequent alerts for failed autodiscovery when the Resonite path hasn't been configured.