### PR TITLE
Increase width of version tooltips to avoid overflowing labels

### DIFF
--- a/ui/src/components/mods/ModVersionStatus.vue
+++ b/ui/src/components/mods/ModVersionStatus.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-tooltip :open-delay="500">
+	<v-tooltip :open-delay="500" model-value>
 		<template #activator="{ props: tooltipProps }">
 			<div class="d-flex h-100 position-relative">
 				<v-scroll-y-transition>
@@ -53,6 +53,6 @@ const tooltipWidth = computed(() => {
 	const anyUnrecognized =
 		mod.installedVersion?.isUnrecognized || mod.latestVersion.isUnrecognized;
 	if (anyUnrecognized) return '8.75em';
-	return '7.25em';
+	return '8.25em';
 });
 </script>


### PR DESCRIPTION
Increases the width of the version status tooltips on mods in the mod tables to avoid the labels overflowing.

Fixes #190