### PR TITLE
Upgrade native_db to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,9 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "native_db"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2628b11ef6a479db783b2fabefbd4d2f3ffbe825cc2154cfe3d3c9c779734"
+checksum = "ed54dc7c04d201260247cbd1de99d459297fe80f0a79daa4598ef9c6ce4d7782"
 dependencies = [
  "native_db_macro",
  "native_model",
@@ -2749,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "native_db_macro"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e80d1609e8eb0404ea5de614883cdf159b6d875c370c0c1bfbc21d80772399e"
+checksum = "163533e9cf510dfdc1f417462beb3651fccdcb9dd027533d85f780081ee212e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3941,8 +3941,6 @@ dependencies = [
  "clap",
  "itertools",
  "log",
- "native_db",
- "once_cell",
  "opener",
  "path-clean",
  "reqwest",

--- a/crates/resolute/Cargo.toml
+++ b/crates/resolute/Cargo.toml
@@ -21,7 +21,7 @@ futures-util = "0.3"
 path-clean = "1.0"
 sha2 = "0.10"
 steamlocate = "2.0.0-beta.2"
-native_db = { version = "0.6", optional = true }
+native_db = { version = "0.7", optional = true }
 native_model = { version = "0.4", optional = true }
 redb = { version = "2.0", optional = true }
 

--- a/crates/resolute/src/mods.rs
+++ b/crates/resolute/src/mods.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 #[cfg(feature = "db")]
-use native_db::{native_db, InnerKeyValue};
+use native_db::{native_db, ToKey};
 #[cfg(feature = "db")]
 use native_model::{native_model, Model};
 

--- a/crates/tauri-app/Cargo.toml
+++ b/crates/tauri-app/Cargo.toml
@@ -22,8 +22,6 @@ clap = { version = "4.5", features = ["derive"] }
 url = "2.5"
 log = "0.4"
 sha2 = "0.10"
-native_db = "0.6"
-once_cell = "1.19"
 itertools = "0.13"
 path-clean = "1.0"
 opener = "0.7"

--- a/crates/tauri-app/src/main.rs
+++ b/crates/tauri-app/src/main.rs
@@ -77,8 +77,6 @@ use std::{env, error::Error, io, thread, time::Duration};
 use anyhow::{bail, Context};
 use clap::Parser;
 use log::{debug, error, info, warn, LevelFilter};
-use native_db::DatabaseBuilder;
-use once_cell::sync::Lazy;
 use resolute::{db::ResoluteDatabase, discover, manager::ModManager, manifest};
 use tauri::{async_runtime, App, AppHandle, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder, WindowEvent};
 use tauri_plugin_deep_link::DeepLinkExt;
@@ -89,13 +87,6 @@ use url::Url;
 
 mod commands;
 mod settings;
-
-/// Lazily-initialized database builder for the Resolute DB
-static DB_BUILDER: Lazy<DatabaseBuilder> = Lazy::new(|| {
-	let mut builder = DatabaseBuilder::new();
-	ResoluteDatabase::define_models(&mut builder).expect("unable to define models on database builder");
-	builder
-});
 
 #[derive(Debug, Parser)]
 #[command(version)]
@@ -268,7 +259,7 @@ async fn init(app: &AppHandle) -> Result<(), anyhow::Error> {
 			.app_data_dir()
 			.context("Unable to get data dir")?
 			.join("resolute.db");
-		let db = ResoluteDatabase::open(&DB_BUILDER, db_path).context("Unable to open database")?;
+		let db = ResoluteDatabase::open(db_path).context("Unable to open database")?;
 
 		// Get the Resonite path setting
 		info!("Retrieving Resonite path from settings store");


### PR DESCRIPTION
Uses the latest version (0.7.0) of native_db for the Resolute database wrapper and simplifies usage from the frontend code.